### PR TITLE
Adds support for multiple instances of the winston-cloudwatch transport. Supports handleExceptions

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ var CloudWatch = winston.transports.CloudWatch = function(options) {
 
 util.inherits(CloudWatch, winston.Transport);
 
-Cloudwatch.prototype.log = function(level, msg, meta, callback) {
+CloudWatch.prototype.log = function(level, msg, meta, callback) {
   var log = { level: level, msg: msg, meta: meta };
   this.cw.add(log);
 

--- a/index.js
+++ b/index.js
@@ -5,19 +5,20 @@ var util = require('util'),
 var CloudWatch = winston.transports.CloudWatch = function(options) {
   this.name = 'CloudWatch';
   this.level = options.level || 'info';
+  this.handleExceptions = options.handleExceptions || false;
 
-  cloudwatchIntegration.init(options.logGroupName, options.logStreamName,
+  this.cw = cloudwatchIntegration.init(options.logGroupName, options.logStreamName,
                              options.awsAccessKeyId, options.awsSecretKey, options.awsRegion);
 };
 
 util.inherits(CloudWatch, winston.Transport);
 
-CloudWatch.prototype.log = function(level, msg, meta, callback) {
+Cloudwatch.prototype.log = function(level, msg, meta, callback) {
   var log = { level: level, msg: msg, meta: meta };
-  cloudwatchIntegration.add(log);
+  this.cw.add(log);
 
   // do not wait, just return right away
   callback(null, true);
-};
+}
 
 module.exports = CloudWatch;

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var CloudWatch = winston.transports.CloudWatch = function(options) {
   this.level = options.level || 'info';
   this.handleExceptions = options.handleExceptions || false;
 
-  this.cw = cloudwatchIntegration.init(options.logGroupName, options.logStreamName,
+  this.cw = new cloudwatchIntegration(options.logGroupName, options.logStreamName,
                              options.awsAccessKeyId, options.awsSecretKey, options.awsRegion);
 };
 

--- a/lib/cloudwatch-integration.js
+++ b/lib/cloudwatch-integration.js
@@ -1,59 +1,61 @@
 var AWS = require('aws-sdk'),
     cloudwatchlogs,
-    _ = require('lodash'),
-    logEvents = [],
-    logGroupName = '',
-    logStreamName = '',
-    intervalId;
+    _ = require('lodash');
 
-module.exports.init = function(awsLogGroupName, awsLogStreamName, awsAccessKeyId, awsSecretKey, awsRegion) {
+module.exports = function(awsLogGroupName, awsLogStreamName, awsAccessKeyId, awsSecretKey, awsRegion) {
   if (awsAccessKeyId && awsSecretKey && awsRegion) {
-    cloudwatchlogs = new AWS.CloudWatchLogs({accessKeyId: awsAccessKeyId, secretAccessKey: awsSecretKey, region: awsRegion});
+    this.cloudwatchlogs = new AWS.CloudWatchLogs({
+      accessKeyId: awsAccessKeyId,
+      secretAccessKey: awsSecretKey,
+      region: awsRegion
+    });
   } else {
-    cloudwatchlogs = new AWS.CloudWatchLogs();
+    this.cloudwatchlogs = new AWS.CloudWatchLogs();
   }
-  logGroupName = awsLogGroupName;
-  logStreamName = awsLogStreamName;
+  this.logGroupName = awsLogGroupName;
+  this.logStreamName = awsLogStreamName;
+  this.logEvents = [];
+  this.intervalId = undefined;
 };
 
 module.exports.add = function(log) {
-  logEvents.push({
+  this.logEvents.push({
     message: [log.level, log.msg, JSON.stringify(log.meta, null, '  ')].join(' - '),
-    timestamp: new Date().getTime()      
+    timestamp: new Date().getTime()
   });
-  
+
   var lastFree = new Date().getTime();
   function upload() {
     if (new Date().getTime() - 2000 > lastFree) {
-      token(function(err, sequenceToken) {
+      token(this.logGroupName, this.logStreamName, function(err, sequenceToken) {
         if (err) {
           return console.log(err, err.stack);
         }
-        
+
         if (logEvents.length <= 0) {
           return;
         }
-        
+
         var payload = {
           sequenceToken: sequenceToken,
-          logGroupName: logGroupName,
-          logStreamName: logStreamName,
-          logEvents: logEvents.splice(0, 10)
+          logGroupName: this.logGroupName,
+          logStreamName: this.logStreamName,
+          logEvents: this.logEvents.splice(0, 10)
         };
 
-        cloudwatchlogs.putLogEvents(payload, function(err, data) {
+        this.cloudwatchlogs.putLogEvents(payload, function(err, data) {
           if (err) return console.log(err, err.stack);
           lastFree = new Date().getTime();
         });
       });
-    }    
+    }
   }
-  if (!intervalId) {
-    intervalId = setInterval(upload, 1000);
+  if (!this.intervalId) {
+    this.intervalId = setInterval(upload, 1000);
   }
 };
 
-function token(cb) {
+function token(logGroupName, logStreamName, cb) {
   cloudwatchlogs.describeLogStreams({
     logGroupName: logGroupName
   }, function(err, data) {

--- a/lib/cloudwatch-integration.js
+++ b/lib/cloudwatch-integration.js
@@ -1,4 +1,5 @@
 var AWS = require('aws-sdk'),
+  async = require('async'),
   _ = require('lodash');
 
 module.exports = function(awsLogGroupName, awsLogStreamName, awsAccessKeyId, awsSecretKey, awsRegion) {
@@ -14,45 +15,41 @@ module.exports = function(awsLogGroupName, awsLogStreamName, awsAccessKeyId, aws
   this.logGroupName = awsLogGroupName;
   this.logStreamName = awsLogStreamName;
   this.logEvents = [];
-  this.intervalId = undefined;
+
+  var self = this;
+  async.forever(function(next) {
+    setTimeout(function() {
+      upload.call(self, next);
+    }, 1000);
+  }, function (err) {
+    console.log(err);
+  });
 };
+
+function upload(next) {
+  if(this.logEvents.length <= 0) return next();
+
+  var self = this;
+
+  token(this.cloudwatchlogs, this.logGroupName, this.logStreamName, function(err, sequenceToken) {
+    if(err) return next(err);
+
+    var payload = {
+      sequenceToken: sequenceToken,
+      logGroupName: self.logGroupName,
+      logStreamName: self.logStreamName,
+      logEvents: self.logEvents.splice(0, 10)
+    };
+
+    self.cloudwatchlogs.putLogEvents(payload, next);
+  });
+}
 
 module.exports.prototype.add = function(log) {
   this.logEvents.push({
     message: [log.level, log.msg, JSON.stringify(log.meta, null, '  ')].join(' - '),
     timestamp: new Date().getTime()
   });
-
-  var lastFree = new Date().getTime();
-  var self = this;
-  function upload() {
-    if (new Date().getTime() - 2000 > lastFree) {
-      token(self.cloudwatchlogs, self.logGroupName, self.logStreamName, function(err, sequenceToken) {
-        if (err) {
-          return console.log(err, err.stack);
-        }
-
-        if (self.logEvents.length <= 0) {
-          return;
-        }
-
-        var payload = {
-          sequenceToken: sequenceToken,
-          logGroupName: self.logGroupName,
-          logStreamName: self.logStreamName,
-          logEvents: self.logEvents.splice(0, 10)
-        };
-
-        self.cloudwatchlogs.putLogEvents(payload, function(err, data) {
-          if (err) return console.log(err, err.stack);
-          lastFree = new Date().getTime();
-        });
-      });
-    }
-  }
-  if (!this.intervalId) {
-    this.intervalId = setInterval(upload, 1000);
-  }
 };
 
 function token(cloudwatchlogs, logGroupName, logStreamName, cb) {

--- a/lib/cloudwatch-integration.js
+++ b/lib/cloudwatch-integration.js
@@ -1,6 +1,5 @@
 var AWS = require('aws-sdk'),
-    cloudwatchlogs,
-    _ = require('lodash');
+  _ = require('lodash');
 
 module.exports = function(awsLogGroupName, awsLogStreamName, awsAccessKeyId, awsSecretKey, awsRegion) {
   if (awsAccessKeyId && awsSecretKey && awsRegion) {
@@ -18,32 +17,33 @@ module.exports = function(awsLogGroupName, awsLogStreamName, awsAccessKeyId, aws
   this.intervalId = undefined;
 };
 
-module.exports.add = function(log) {
+module.exports.prototype.add = function(log) {
   this.logEvents.push({
     message: [log.level, log.msg, JSON.stringify(log.meta, null, '  ')].join(' - '),
     timestamp: new Date().getTime()
   });
 
   var lastFree = new Date().getTime();
+  var self = this;
   function upload() {
     if (new Date().getTime() - 2000 > lastFree) {
-      token(this.logGroupName, this.logStreamName, function(err, sequenceToken) {
+      token(self.cloudwatchlogs, self.logGroupName, self.logStreamName, function(err, sequenceToken) {
         if (err) {
           return console.log(err, err.stack);
         }
 
-        if (logEvents.length <= 0) {
+        if (self.logEvents.length <= 0) {
           return;
         }
 
         var payload = {
           sequenceToken: sequenceToken,
-          logGroupName: this.logGroupName,
-          logStreamName: this.logStreamName,
-          logEvents: this.logEvents.splice(0, 10)
+          logGroupName: self.logGroupName,
+          logStreamName: self.logStreamName,
+          logEvents: self.logEvents.splice(0, 10)
         };
 
-        this.cloudwatchlogs.putLogEvents(payload, function(err, data) {
+        self.cloudwatchlogs.putLogEvents(payload, function(err, data) {
           if (err) return console.log(err, err.stack);
           lastFree = new Date().getTime();
         });
@@ -55,7 +55,7 @@ module.exports.add = function(log) {
   }
 };
 
-function token(logGroupName, logStreamName, cb) {
+function token(cloudwatchlogs, logGroupName, logStreamName, cb) {
   cloudwatchlogs.describeLogStreams({
     logGroupName: logGroupName
   }, function(err, data) {
@@ -65,4 +65,4 @@ function token(logGroupName, logStreamName, cb) {
     });
     cb(err, logStream.uploadSequenceToken);
   });
-}
+};

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   "dependencies": {
     "aws-sdk": "^2.1.8",
     "lodash": "^3.0.1",
-    "winston": "^0.9.0"
+    "winston": "^0.9.0",
+    "async": "~0.9.0"
   },
   "devDependencies": {
     "clarify": "^1.0.5",


### PR DESCRIPTION
These changes allow for multiple winston-cloudwatch transports to be created. For example, this may be necessary if you would like different error levels to be reported to different log streams or groups.

It also adds support for the handleExceptions option by passing adding it as a property to the transport instance.