### PR TITLE
Placed winston as a peerDependency (and updated version)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,10 +17,12 @@
   "repository": "https://github.com/lazywithclass/winston-cloudwatch",
   "author": "me@lazywithclass.com",
   "license": "MIT",
+  "peerDependencies": {
+    "winston": "^1.0.0"
+  },
   "dependencies": {
     "aws-sdk": "^2.1.8",
-    "lodash": "^3.0.1",
-    "winston": "^0.9.0"
+    "lodash": "^3.0.1"
   },
   "devDependencies": {
     "clarify": "^1.0.5",


### PR DESCRIPTION
Since `winston` exports a singleton, having it as a `dependency` in `package.json` makes `winston-cloudwatch` reference the one installed under its `node_modules` and not the one installed under the application's `node_modules`. Making it a `peerDependency` solves this issue.