### PR TITLE
add option to send log object as json

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var CloudWatch = winston.transports.CloudWatch = function(options) {
   this.level = options.level || 'info';
 
   cloudwatchIntegration.init(options.logGroupName, options.logStreamName,
-                             options.awsAccessKeyId, options.awsSecretKey, options.awsRegion);
+                             options.awsAccessKeyId, options.awsSecretKey, options.awsRegion, options.jsonMessage);
 };
 
 util.inherits(CloudWatch, winston.Transport);

--- a/lib/cloudwatch-integration.js
+++ b/lib/cloudwatch-integration.js
@@ -4,9 +4,10 @@ var AWS = require('aws-sdk'),
     logEvents = [],
     logGroupName = '',
     logStreamName = '',
+    messageAsJSON,
     intervalId;
 
-module.exports.init = function(awsLogGroupName, awsLogStreamName, awsAccessKeyId, awsSecretKey, awsRegion) {
+module.exports.init = function(awsLogGroupName, awsLogStreamName, awsAccessKeyId, awsSecretKey, awsRegion, jsonMessage) {
   if (awsAccessKeyId && awsSecretKey && awsRegion) {
     cloudwatchlogs = new AWS.CloudWatchLogs({accessKeyId: awsAccessKeyId, secretAccessKey: awsSecretKey, region: awsRegion});
   } else {
@@ -14,11 +15,13 @@ module.exports.init = function(awsLogGroupName, awsLogStreamName, awsAccessKeyId
   }
   logGroupName = awsLogGroupName;
   logStreamName = awsLogStreamName;
+  messageAsJSON = jsonMessage;
 };
 
 module.exports.add = function(log) {
   logEvents.push({
-    message: [log.level, log.msg, JSON.stringify(log.meta, null, '  ')].join(' - '),
+    //message: [log.level, log.msg, JSON.stringify(log.meta, null, '  ')].join(' - '),
+    message: messageAsJSON ? JSON.stringify(log, null, '  ') : [log.level, log.msg, JSON.stringify(log.meta, null, '  ')].join(' - '),
     timestamp: new Date().getTime()      
   });
   

--- a/lib/cloudwatch-integration.js
+++ b/lib/cloudwatch-integration.js
@@ -20,7 +20,6 @@ module.exports.init = function(awsLogGroupName, awsLogStreamName, awsAccessKeyId
 
 module.exports.add = function(log) {
   logEvents.push({
-    //message: [log.level, log.msg, JSON.stringify(log.meta, null, '  ')].join(' - '),
     message: messageAsJSON ? JSON.stringify(log, null, '  ') : [log.level, log.msg, JSON.stringify(log.meta, null, '  ')].join(' - '),
     timestamp: new Date().getTime()      
   });


### PR DESCRIPTION
CloudWatch Logs accepts JSON logs.

Allowing the log object to be sent as JSON enables the use of JSON filters within cloudwatch, http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/FilterAndPatternSyntax.html

    {$.level=debug}

This pull request adds the option to send the log object as JSON.