### PR TITLE
Adding paging to describeLogStreams

### DIFF
--- a/lib/cloudwatch-integration.js
+++ b/lib/cloudwatch-integration.js
@@ -19,9 +19,9 @@ module.exports.init = function(awsLogGroupName, awsLogStreamName, awsAccessKeyId
 module.exports.add = function(log) {
   logEvents.push({
     message: [log.level, log.msg, JSON.stringify(log.meta, null, '  ')].join(' - '),
-    timestamp: new Date().getTime()      
+    timestamp: new Date().getTime()
   });
-  
+
   var lastFree = new Date().getTime();
   function upload() {
     if (new Date().getTime() - 2000 > lastFree) {
@@ -29,11 +29,11 @@ module.exports.add = function(log) {
         if (err) {
           return console.log(err, err.stack);
         }
-        
+
         if (logEvents.length <= 0) {
           return;
         }
-        
+
         var payload = {
           sequenceToken: sequenceToken,
           logGroupName: logGroupName,
@@ -46,21 +46,36 @@ module.exports.add = function(log) {
           lastFree = new Date().getTime();
         });
       });
-    }    
+    }
   }
   if (!intervalId) {
     intervalId = setInterval(upload, 1000);
   }
 };
 
+function findLogStream(logGroupName, cb) {
+  var next = function(token) {
+    cloudwatchlogs.describeLogStreams({
+      logGroupName: logGroupName,
+      logStreamNamePrefix: logStreamName
+    }, function(err, data) {
+      if (err) return cb(err);
+      var matches = _.find(data.logStreams, function(logStream) {
+        return (logStream.logStreamName === logStreamName);
+      });
+      if (matches.length) {
+        cb(null, matches[0]);
+      } else if (data.nextToken) {
+        next(data.nextToken);
+      }
+    })
+  }
+  next();
+}
+
 function token(cb) {
-  cloudwatchlogs.describeLogStreams({
-    logGroupName: logGroupName
-  }, function(err, data) {
+  findLogStream(logGroupName, function(err, logStream) {
     if (err) return cb(err);
-    var logStream = _.find(data.logStreams, function(logStream) {
-      return logStream.logStreamName === logStreamName;
-    });
-    cb(err, logStream.uploadSequenceToken);
+    cb(null, logStream.uploadSequenceToken);
   });
 }

--- a/lib/cloudwatch-integration.js
+++ b/lib/cloudwatch-integration.js
@@ -53,19 +53,22 @@ module.exports.add = function(log) {
   }
 };
 
-function findLogStream(logGroupName, cb) {
+function findLogStream(logGroupName, logStreamName, cb) {
   var next = function(token) {
-    cloudwatchlogs.describeLogStreams({
+    var params = {
       logGroupName: logGroupName,
       logStreamNamePrefix: logStreamName
-    }, function(err, data) {
+    };
+    cloudwatchlogs.describeLogStreams(params, function(err, data) {
       if (err) return cb(err);
       var matches = _.find(data.logStreams, function(logStream) {
         return (logStream.logStreamName === logStreamName);
       });
       if (matches.length) {
         cb(null, matches[0]);
-      } else if (data.nextToken) {
+      } else if (!data.nextToken) {
+        cb(new Error('Stream not found'));
+      } else {
         next(data.nextToken);
       }
     })
@@ -74,8 +77,13 @@ function findLogStream(logGroupName, cb) {
 }
 
 function token(cb) {
-  findLogStream(logGroupName, function(err, logStream) {
-    if (err) return cb(err);
+  findLogStream(logGroupName, logStreamName, function(err, logStream) {
+    if (err) {
+      return cb(err);
+    }
+    if (typeof logStream.uploadSequenceToken !== 'string') {
+      return cb(new Error('Upload sequence token not found'));
+    }
     cb(null, logStream.uploadSequenceToken);
   });
 }


### PR DESCRIPTION
The call to `describeLogStreams` didn't take `nextToken` into account, making it crash on groups with many streams. So I fixed that first by adding support for paging.

Then I noticed the `logStreamNamePrefix` option, which makes paging unnecessary in most cases. Still, it's good to have it in there.