### PR TITLE
Adding support for a proxy server

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ This is the list of options you could pass as argument to `winston.add`:
  * awsSecretKey
  * awsRegion
  * jsonMessage - `boolean`, format the message as JSON
+ * proxyServer
 
 AWS keys are usually picked by aws-sdk so you don't have to specify them, I provided the option just in case. Remember that `awsRegion` should still be set if you're using IAM roles.
 

--- a/index.js
+++ b/index.js
@@ -7,7 +7,8 @@ var CloudWatch = winston.transports.CloudWatch = function(options) {
   this.level = options.level || 'info';
 
   cloudwatchIntegration.init(options.logGroupName, options.logStreamName,
-                             options.awsAccessKeyId, options.awsSecretKey, options.awsRegion, options.jsonMessage);
+                             options.awsAccessKeyId, options.awsSecretKey,
+                             options.awsRegion, options.jsonMessage, options.proxyServer);
 };
 
 util.inherits(CloudWatch, winston.Transport);

--- a/lib/cloudwatch-integration.js
+++ b/lib/cloudwatch-integration.js
@@ -7,7 +7,14 @@ var AWS = require('aws-sdk'),
     messageAsJSON,
     intervalId;
 
-module.exports.init = function(awsLogGroupName, awsLogStreamName, awsAccessKeyId, awsSecretKey, awsRegion, jsonMessage) {
+module.exports.init = function(awsLogGroupName, awsLogStreamName, awsAccessKeyId, awsSecretKey, awsRegion, jsonMessage, proxyServer) {
+   if (proxyServer) {
+      AWS.config.update({
+          httpOptions: {
+              agent: require('proxy-agent')(proxyServer)
+          }
+      });
+  }
   if (awsAccessKeyId && awsSecretKey && awsRegion) {
     cloudwatchlogs = new AWS.CloudWatchLogs({accessKeyId: awsAccessKeyId, secretAccessKey: awsSecretKey, region: awsRegion});
   } else if (awsRegion && !awsAccessKeyId && !awsSecretKey) {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   },
   "dependencies": {
     "aws-sdk": "^2.2.35",
-    "lodash": "^4.3.0"
+    "lodash": "^4.3.0",
+    "proxy-agent": "^2.0.0"
   },
   "devDependencies": {
     "clarify": "^1.0.5",


### PR DESCRIPTION
Using winston-cloudwatch behind a proxy won't work, so I've added this change so you can specify the proxy server on the AWS object instance.

Let me know your thoughts. Thanks