### PR TITLE
We can now pass AWS.CloudWatchLogs options

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,16 +32,22 @@ var WinstonCloudWatch = function(options) {
     });
   }
 
+  var config = {};
+
   if (awsAccessKeyId && awsSecretKey && awsRegion) {
-    this.cloudwatchlogs = new AWS.CloudWatchLogs({accessKeyId: awsAccessKeyId, secretAccessKey: awsSecretKey, region: awsRegion});
+    config = {accessKeyId: awsAccessKeyId, secretAccessKey: awsSecretKey, region: awsRegion};
   } else if (awsRegion && !awsAccessKeyId && !awsSecretKey) {
     // Amazon SDK will automatically pull access credentials
     // from IAM Role when running on EC2 but region still
     // needs to be configured
-    this.cloudwatchlogs = new AWS.CloudWatchLogs({region: awsRegion});
-  } else {
-    this.cloudwatchlogs = new AWS.CloudWatchLogs();
+    config = {region: awsRegion};
   }
+
+  if(options.awsOptions){
+    config = extend(config, options.awsOptions);
+  }
+
+  this.cloudwatchlogs = new AWS.CloudWatchLogs(config);
 };
 
 util.inherits(WinstonCloudWatch, winston.Transport);
@@ -85,5 +91,12 @@ WinstonCloudWatch.prototype.add = function(log) {
 
 function stringify(o) { return JSON.stringify(o, null, '  '); }
 
+function extend(src, obj){
+  Object.keys(obj).map(function(key){
+    src[key] = obj[key];
+  });
+
+  return src;
+}
 
 module.exports = WinstonCloudWatch;


### PR DESCRIPTION
To solve this isse aws/aws-sdk-js#527, I needed the ability to pass options to the `AWS.CloudWatchLogs` constructor.

If the options object contains a `awsOptions` key, this will merged and passed in to the constructor