### PR TITLE
fix getStream when there are many streams in the group

### DIFF
--- a/lib/cloudwatch-integration.js
+++ b/lib/cloudwatch-integration.js
@@ -53,7 +53,10 @@ lib.ensureGroupPresent = function ensureGroupPresent(aws, name, cb) {
 };
 
 lib.getStream = function getStream(aws, groupName, streamName, cb) {
-  var params = { logGroupName: groupName };
+  var params = { 
+    logGroupName: groupName,
+    logStreamNamePrefix: streamName
+  };
 
   aws.describeLogStreams(params, function(err, data) {
     if (err) return cb(err);


### PR DESCRIPTION
fix getStream when there are many streams in the group by passing log StreamNamePrefix to CWL. CWL only returns the first 50 matches, so the one we just created will get missed with a broad search. For me this is currently resulting in no logs getting posted, and, worse, a memory leak: getStream never finished so upload never gets to the point of taking items out of the queue.