### PR TITLE
Fixes a bug when under heavy load and and adds batching and truncating features 

### DIFF
--- a/lib/cloudwatch-integration.js
+++ b/lib/cloudwatch-integration.js
@@ -1,26 +1,59 @@
+var LIMITS = {
+    MAX_EVENT_MSG_SIZE_BYTES: 256000,   // The real max size is 262144, we leave some room for overhead on each message
+    MAX_BATCH_SIZE_BYTES: 1000000,      // We leave some fudge factor here too.
+    MAX_BATCH_SIZE_COUNT : 100          // Bigger number means fewer requests to post.
+};
+
 var _ = require('lodash'),
     async = require('async');
 
 var lib = {};
 
 lib.upload = function(aws, groupName, streamName, logEvents, cb) {
-  lib.getToken(aws, groupName, streamName, function(err, token) {
+
+    // Trying to send a batch before the last completed would cause InvalidSequenceTokenException.
+    if (lib.postingEvents || logEvents.length <= 0) {
+      return cb();
+    }
+
+    lib.getToken(aws, groupName, streamName, function(err, token) {
+
     if (err) {
       return cb(err);
     }
 
-    if (logEvents.length <= 0) {
-      return cb();
+
+    var entryIndex = 0;
+    var bytes = 0;
+    while(entryIndex < logEvents.length && entryIndex <= LIMITS.MAX_BATCH_SIZE_COUNT) {
+        var ev = logEvents[entryIndex];
+        var evSize = ev ? Buffer.byteLength(ev.message, 'utf8') : 0; // Unit tests pass null elements
+        // Handle single entries that are too big.
+        if(evSize > LIMITS.MAX_EVENT_MSG_SIZE_BYTES) {
+            evSize = LIMITS.MAX_EVENT_MSG_SIZE_BYTES;
+            ev.message = ev.message.substring(0, evSize); // NOTE: For MBCS this may truncate the string more than needed
+            const msgTooBigErr = new Error('Message Truncated because it exceeds the CloudWatch size limit');
+            msgTooBigErr.logEvent = ev;
+            cb(msgTooBigErr);
+        }
+        // Make sure batch size does not go above the limits.
+        if(bytes + evSize > LIMITS.MAX_BATCH_SIZE_BYTES) break;
+        bytes += evSize;
+        entryIndex++;
     }
 
     var payload = {
       logGroupName: groupName,
       logStreamName: streamName,
-      logEvents: logEvents.splice(0, 20)
+      logEvents: logEvents.splice(0, entryIndex)
     };
     if (token) payload.sequenceToken = token;
 
-    aws.putLogEvents(payload, cb);
+    lib.postingEvents = true;
+    aws.putLogEvents(payload, function(err) {
+        lib.postingEvents = false;
+        cb(err);
+    });
   });
 };
 

--- a/lib/cloudwatch-integration.js
+++ b/lib/cloudwatch-integration.js
@@ -12,7 +12,7 @@ var lib = {};
 lib.upload = function(aws, groupName, streamName, logEvents, cb) {
 
     // Trying to send a batch before the last completed would cause InvalidSequenceTokenException.
-    if (lib.postingEvents || logEvents.length <= 0) {
+    if (lib._postingEvents || logEvents.length <= 0) {
       return cb();
     }
 
@@ -49,9 +49,9 @@ lib.upload = function(aws, groupName, streamName, logEvents, cb) {
     };
     if (token) payload.sequenceToken = token;
 
-    lib.postingEvents = true;
+    lib._postingEvents = true;
     aws.putLogEvents(payload, function(err) {
-        lib.postingEvents = false;
+        lib._postingEvents = false;
         cb(err);
     });
   });

--- a/test/cloudwatch-integration.js
+++ b/test/cloudwatch-integration.js
@@ -36,7 +36,7 @@ describe('cloudwatch-integration', function() {
 
     it('truncates very large messages and alerts the error handler', function(done) {
       var BIG_MSG_LEN = 300000;
-      const events = [{ message : new Array(BIG_MSG_LEN).fill('A').join(''), timestamp : new Date().toISOString()}];
+      const events = [{ message : new Array(BIG_MSG_LEN).join('A'), timestamp : new Date().toISOString()}];
       var errCalled = false;
       lib.upload(aws, 'group', 'stream', events, function(err) {
         if(err) {
@@ -52,7 +52,7 @@ describe('cloudwatch-integration', function() {
 
     it('batches messages so as not to exceed CW limits', function(done) {
       var BIG_MSG_LEN = 250000; // under single limit but a few of these will exceed the batch limit
-      var bigMessage = new Array(BIG_MSG_LEN).fill('A').join('');
+      var bigMessage = new Array(BIG_MSG_LEN).join(' ');
       const events = [
         { message : bigMessage, timestamp : new Date().toISOString()},
         { message : bigMessage, timestamp : new Date().toISOString()},

--- a/test/cloudwatch-integration.js
+++ b/test/cloudwatch-integration.js
@@ -21,6 +21,58 @@ describe('cloudwatch-integration', function() {
       console.error.restore();
     });
 
+    it('ignores upload calls if already in progress', function(done) {
+      const events = [{ message : "test message", timestamp : new Date().toISOString()}];
+      aws.putLogEvents.onFirstCall().returns(); // Don't call call back to simulate ongoing request.
+      aws.putLogEvents.onSecondCall().yields();
+      lib.upload(aws, 'group', 'stream', events, function(){});
+      lib.upload(aws, 'group', 'stream', events, function() {
+        // The second upload call should get ignored
+        aws.putLogEvents.calledOnce.should.equal(true);
+        lib._postingEvents = false; // reset
+        done()
+      });
+    });
+
+    it('truncates very large messages and alerts the error handler', function(done) {
+      var BIG_MSG_LEN = 300000;
+      const events = [{ message : new Array(BIG_MSG_LEN).fill('A').join(''), timestamp : new Date().toISOString()}];
+      var errCalled = false;
+      lib.upload(aws, 'group', 'stream', events, function(err) {
+        if(err) {
+          errCalled = true;
+          return;
+        }
+        errCalled.should.equal(true);
+        aws.putLogEvents.calledOnce.should.equal(true);
+          aws.putLogEvents.args[0][0].logEvents[0].message.length.should.be.lessThan(BIG_MSG_LEN); // Truncated
+        done()
+      });
+    });
+
+    it('batches messages so as not to exceed CW limits', function(done) {
+      var BIG_MSG_LEN = 250000; // under single limit but a few of these will exceed the batch limit
+      var bigMessage = new Array(BIG_MSG_LEN).fill('A').join('');
+      const events = [
+        { message : bigMessage, timestamp : new Date().toISOString()},
+        { message : bigMessage, timestamp : new Date().toISOString()},
+        { message : bigMessage, timestamp : new Date().toISOString()},
+        { message : bigMessage, timestamp : new Date().toISOString()},
+        { message : bigMessage, timestamp : new Date().toISOString()}
+      ];
+      lib.upload(aws, 'group', 'stream', events, function(err) {
+        aws.putLogEvents.calledOnce.should.equal(true);
+        aws.putLogEvents.args[0][0].logEvents.length.should.equal(4); // First Batch
+        // Now, finish.
+        lib.upload(aws, 'group', 'stream', events, function(err) {
+          aws.putLogEvents.args[1][0].logEvents.length.should.equal(1); // Second Batch
+          done()
+        });
+      });
+    });
+
+
+
     it('puts log events', function(done) {
       lib.upload(aws, 'group', 'stream', Array(20), function() {
         aws.putLogEvents.calledOnce.should.equal(true);


### PR DESCRIPTION
I had three problems using this library in a production system, all three I have addressed in this PR. 

1. BUG - while under heavy load, random InvalidSequenceTokenExceptions would be returned from CW and log messages were lost. The reason is that the timer tried to send the next batch before the current one completed, so the next sequence token was not available yet. 

2. A batch with a single very large message that exceeds CW's limit for a single event would cause an error response from CW and the entire batch of messages to be lost. 

3. Even if individual messages are below the CW max for a single message, it's possible that a few messages together can add up to more than the CW limit for a single upload. This would cause an error response from CW and the entire batch of messages to be lost. 

Additionally, now since we know that we won't exceed the limits for CW, we can send larger batches to be more efficient (fewer individual HTTP requests to CW). 