### PR TITLE
Send logs immediately when catching an exception

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,8 +63,8 @@ WinstonCloudWatch.prototype.log = function(level, msg, meta, callback) {
   }
     
   // clear interval and send logs immediately
-  clearInterval(self.intervalId);
-  self.intervalId = null;
+  clearInterval(this.intervalId);
+  this.intervalId = null;
     
   this.submit(callback);
 };


### PR DESCRIPTION
Check if message start with the string "uncaughtException: " and if so, send all logs immediately with callback when done.