### PR TITLE
Protect logEvents from overlapped calls to upload

### DIFF
--- a/lib/cloudwatch-integration.js
+++ b/lib/cloudwatch-integration.js
@@ -21,56 +21,63 @@ lib.upload = function(aws, groupName, streamName, logEvents, cb) {
     return cb();
   }
 
-  lib.getToken(aws, groupName, streamName, function(err, token) {
-
-    if (err) {
-      debug('error getting token', err, true);
-      return cb(err);
-    }
-
-    var entryIndex = 0;
-    var bytes = 0;
-    while (entryIndex < logEvents.length &&
-           entryIndex <= LIMITS.MAX_BATCH_SIZE_COUNT) {
-      var ev = logEvents[entryIndex];
-      // unit tests pass null elements
-      var evSize = ev ? Buffer.byteLength(ev.message, 'utf8') : 0; 
-      if(evSize > LIMITS.MAX_EVENT_MSG_SIZE_BYTES) {
-        evSize = LIMITS.MAX_EVENT_MSG_SIZE_BYTES;
-        ev.message = ev.message.substring(0, evSize); 
-        const msgTooBigErr = new Error('Message Truncated because it exceeds the CloudWatch size limit');
-        msgTooBigErr.logEvent = ev;
-        cb(msgTooBigErr);
-      }
-      if (bytes + evSize > LIMITS.MAX_BATCH_SIZE_BYTES) break;
-      bytes += evSize;
-      entryIndex++;
-    }
-
-    var payload = {
-      logGroupName: groupName,
-      logStreamName: streamName,
-      logEvents: logEvents.splice(0, entryIndex)
-    };
-    if (token) payload.sequenceToken = token;
-
-    lib._postingEvents = true;
-    debug('send to aws');
-    aws.putLogEvents(payload, function(err) {
-      if (err) {
-        if (err.code === 'InvalidSequenceTokenException') {
-          debug('InvalidSequenceTokenException, retrying', true)
-          submitWithAnotherToken(aws, groupName, streamName, payload, cb)
-        } else {
-          debug('error during putLogEvents', err, true)
-          retrySubmit(aws, payload, 3, cb)
-        }
-      } else  {
-        lib._postingEvents = false;
-        cb()
-      }
-    });
+  lib._postingEvents = true;
+  safeUpload(function(err) {
+    lib._postingEvents = false;
+    return cb(err);
   });
+
+  function safeUpload(cb) {
+    lib.getToken(aws, groupName, streamName, function(err, token) {
+
+      if (err) {
+        debug('error getting token', err, true);
+        return cb(err);
+      }
+
+      var entryIndex = 0;
+      var bytes = 0;
+      while (entryIndex < logEvents.length &&
+             entryIndex <= LIMITS.MAX_BATCH_SIZE_COUNT) {
+        var ev = logEvents[entryIndex];
+        // unit tests pass null elements
+        var evSize = ev ? Buffer.byteLength(ev.message, 'utf8') : 0;
+        if(evSize > LIMITS.MAX_EVENT_MSG_SIZE_BYTES) {
+          evSize = LIMITS.MAX_EVENT_MSG_SIZE_BYTES;
+          ev.message = ev.message.substring(0, evSize);
+          const msgTooBigErr = new Error('Message Truncated because it exceeds the CloudWatch size limit');
+          msgTooBigErr.logEvent = ev;
+          cb(msgTooBigErr);
+        }
+        if (bytes + evSize > LIMITS.MAX_BATCH_SIZE_BYTES) break;
+        bytes += evSize;
+        entryIndex++;
+      }
+
+      var payload = {
+        logGroupName: groupName,
+        logStreamName: streamName,
+        logEvents: logEvents.splice(0, entryIndex)
+      };
+      if (token) payload.sequenceToken = token;
+
+      debug('send to aws');
+      aws.putLogEvents(payload, function(err) {
+        if (err) {
+          if (err.code === 'InvalidSequenceTokenException') {
+            debug('InvalidSequenceTokenException, retrying', true)
+            submitWithAnotherToken(aws, groupName, streamName, payload, cb)
+          } else {
+            debug('error during putLogEvents', err, true)
+            retrySubmit(aws, payload, 3, cb)
+          }
+        } else  {
+          cb()
+        }
+      });
+    });
+  }
+
 };
 
 function submitWithAnotherToken(aws, groupName, streamName, payload, cb) {

--- a/test/cloudwatch-integration.js
+++ b/test/cloudwatch-integration.js
@@ -21,7 +21,7 @@ describe('cloudwatch-integration', function() {
       console.error.restore();
     });
 
-    it('ignores upload calls if already in progress', function(done) {
+    it('ignores upload calls if putLogEvents already in progress', function(done) {
       const events = [{ message : "test message", timestamp : new Date().toISOString()}];
       aws.putLogEvents.onFirstCall().returns(); // Don't call call back to simulate ongoing request.
       aws.putLogEvents.onSecondCall().yields();
@@ -29,6 +29,19 @@ describe('cloudwatch-integration', function() {
       lib.upload(aws, 'group', 'stream', events, function() {
         // The second upload call should get ignored
         aws.putLogEvents.calledOnce.should.equal(true);
+        lib._postingEvents = false; // reset
+        done()
+      });
+    });
+
+    it('ignores upload calls if getToken already in progress', function(done) {
+      const events = [{ message : "test message", timestamp : new Date().toISOString()}];
+      lib.getToken.onFirstCall().returns(); // Don't call call back to simulate ongoing token request.
+      lib.getToken.onSecondCall().yields(null, 'token');
+      lib.upload(aws, 'group', 'stream', events, function(){});
+      lib.upload(aws, 'group', 'stream', events, function() {
+        // The second upload call should get ignored
+        lib.getToken.calledOnce.should.equal(true);
         lib._postingEvents = false; // reset
         done()
       });


### PR DESCRIPTION
Resolves issue #55 InvalidParameterException: 1 validation error detected, please see my comments in that thread for additional detail.  Essentially, when getToken() is slower than the calls into upload(), we'd clear the contents of logEvents in the callback to one call to getToken(), while blocked waiting for another overlapped call to getToken() to complete. Then when that overlapped call to getToken() also completed, we'd submit a then-empty logEvents array to putLogEvents().

Also, please pardon the horrendous diff; I only changed a few lines of code, but to help future-proof against possibly forgetting to clear _postingEvents when adding any future callback case, I moved most of lib.upload() into a local function safeUpload(), so I only clear _postingEvents in one very obvious place two lines away from where it's set.

That move made the diff really ugly, but if you open them up side-by-side it's much easier to see what I did.

I've deployed it to a live staging environment and will continue to test over the weekend, but wanted to get the PR in ASAP so folks could take a look at it, especially having sat on this issue for so long.

Really sorry I didn't get this in so much sooner, and thanks so much for putting this very useful module together and maintaining it!




