### PR TITLE
Implement the correct way to use library import/require

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,19 @@ Remember to install types for both winston and this library.
 Please refer to [AWS CloudWatch Logs documentation](http://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html) for possible contraints that might affect you.
 Also have a look at [AWS CloudWatch Logs limits](http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/cloudwatch_limits.html).
 
+Usage in ES5
 ```js
 var winston = require('winston'),
-    WinstonCloudWatch = require('../index');
+    WinstonCloudWatch = require('winston-cloudwatch');
+```
 
+Usage in ES6
+```js
+import winston from 'winston';
+import WinstonCloudWatch from 'winston-cloudwatch';
+```
+
+```js
 winston.add(new WinstonCloudWatch({
   logGroupName: 'testing',
   logStreamName: 'first'


### PR DESCRIPTION
The official doc use a `require('../index')` but if it's a library it's better to import the library, I suggest a change to the `README` to use it with the `require` and the `import` method.