### PR TITLE
Update winston-cloudwatch.d.ts

### DIFF
--- a/typescript/winston-cloudwatch.d.ts
+++ b/typescript/winston-cloudwatch.d.ts
@@ -3,7 +3,7 @@ import * as Transport from "winston-transport";
 
 import { CloudWatch, CloudWatchLogs } from "aws-sdk";
 
-export namespace WinstonCloudWatch {
+declare namespace WinstonCloudWatch {
   export type LogObject = { level: string; msg: string; meta?: any };
 
   export interface CloudWatchIntegration {
@@ -66,3 +66,7 @@ export namespace WinstonCloudWatch {
     CloudWatch: CloudwatchTransportInstance;
   }
 }
+
+declare const WinstonCloudWatch: WinstonCloudWatch.CloudWatchIntegration;
+
+export default WinstonCloudWatch;


### PR DESCRIPTION
I try to use this package in my typescript projects. but with this type declaration, typescript throw error like this:

'error TS2351: Cannot use 'new' with an expression whose type lacks a call or construct signature.'

so I added WinstonCloudWatch instance declaration to d.ts file, and this worked very well.


