### PR TITLE
Posting events control per logStream instead of global

### DIFF
--- a/lib/cloudwatch-integration.js
+++ b/lib/cloudwatch-integration.js
@@ -8,21 +8,23 @@ var find = require('lodash.find'),
     async = require('async'),
     debug = require('./utils').debug;
 
-var lib = {};
+var lib = {
+  _postingEvents: {}
+};
 
 lib.upload = function(aws, groupName, streamName, logEvents, retentionInDays, cb) {
   debug('upload', logEvents);
 
   // trying to send a batch before the last completed
   // would cause InvalidSequenceTokenException.
-  if (lib._postingEvents || logEvents.length <= 0) {
+  if (lib._postingEvents[streamName] || logEvents.length <= 0) {
     debug('nothing to do or already doing something');
     return cb();
   }
 
-  lib._postingEvents = true;
+  lib._postingEvents[streamName] = true;
   safeUpload(function(err) {
-    lib._postingEvents = false;
+    lib._postingEvents[streamName] = false;
     return cb(err);
   });
 
@@ -69,7 +71,7 @@ lib.upload = function(aws, groupName, streamName, logEvents, retentionInDays, cb
       };
       if (token) payload.sequenceToken = token;
 
-      lib._postingEvents = true;
+      lib._postingEvents[streamName] = true;
       debug('send to aws');
       aws.putLogEvents(payload, function(err, data) {
         debug('sent to aws, err: ', err, ' data: ', data)
@@ -89,7 +91,7 @@ lib.upload = function(aws, groupName, streamName, logEvents, retentionInDays, cb
             lib._nextToken[previousKeyMapKey(groupName, streamName)] = data.nextSequenceToken;
           }
 
-          lib._postingEvents = false;
+          lib._postingEvents[streamName] = false;
           cb()
         }
       });
@@ -102,7 +104,7 @@ lib.submitWithAnotherToken = function(aws, groupName, streamName, payload, reten
   lib.getToken(aws, groupName, streamName, retentionInDays, function(err, token) {
     payload.sequenceToken = token;
     aws.putLogEvents(payload, function(err) {
-      lib._postingEvents = false;
+      lib._postingEvents[streamName] = false;
       cb(err)
     });
   })
@@ -114,7 +116,7 @@ function retrySubmit(aws, payload, times, cb) {
     if (err && times > 0) {
       retrySubmit(aws, payload, times - 1, cb)
     } else {
-      lib._postingEvents = false;
+      lib._postingEvents[payload.logStreamName] = false;
       cb(err)
     }
   })


### PR DESCRIPTION
# Issue description
When having multiple instances of Winston CloudWatch transport to distinct logStreams running in parallel the submission to one logStream should not concur with the others.

In our scenario we have multiple short living loggers to different logStreams, while one transport was submitting to CloudWatch the others were skipping the submission, because they are short living when we close the logger we were losing the entries that were not sent to CloudWatch.

Illustration:
```
logger1: { logStreamName: 'stream1' }
logger2: { logStreamName: 'stream2' }
```

```
logger1.info(...);
logger2.info(...);

// logger1 starts submitting the logs

// logger2 is closed and logs are flushed
logger2.transports.find(transport => 'kthxbye' in transport).kthxbye(); 

// because logger1 is submitting the logs are not flushed and we lose the entries in logger2
```
