### PR TITLE
Remove limit for batch size count

### DIFF
--- a/lib/cloudwatch-integration.js
+++ b/lib/cloudwatch-integration.js
@@ -1,7 +1,6 @@
 var LIMITS = {
   MAX_EVENT_MSG_SIZE_BYTES: 256000,   // The real max size is 262144, we leave some room for overhead on each message
   MAX_BATCH_SIZE_BYTES: 1000000,      // We leave some fudge factor here too.
-  MAX_BATCH_SIZE_COUNT : 100          // Bigger number means fewer requests to post.
 };
 
 var find = require('lodash.find'),
@@ -47,8 +46,7 @@ lib.upload = function(aws, groupName, streamName, logEvents, retentionInDays, cb
 
       var entryIndex = 0;
       var bytes = 0;
-      while (entryIndex < logEvents.length &&
-             entryIndex <= LIMITS.MAX_BATCH_SIZE_COUNT) {
+      while (entryIndex < logEvents.length) {
         var ev = logEvents[entryIndex];
         // unit tests pass null elements
         var evSize = ev ? Buffer.byteLength(ev.message, 'utf8') : 0;


### PR DESCRIPTION
This limit is actually not listed in AWS's documentation https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/cloudwatch_limits_cwl.html.

And when using it, I found that if your process is logging more than `100` messages within the `uploadRate` window constantly, this creates an always increasing back pressure in the `logEvents` queue that will eventually cause the process to run out of memory without warning.

I think we should stick to AWS actually listed limitations, as this one for example was hard to catch when using it.