### PR TITLE
Feature/allow custom aws cloudwatchlogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,23 @@ Think AWS Lambda for example, you don't want to leave the process running there 
 You could have winston-cloudwatch to flush and stop the setInterval loop (thus exiting), have a look
 at [this example](https://github.com/lazywithclass/winston-cloudwatch/blob/master/examples/flush-and-exit.js).
 
+#### Custom AWS.CloudWatchLogs instance
+
+```js
+const AWS = require('aws-sdk');
+
+AWS.config.update({
+  region: 'us-east-1',
+});
+
+winston.add(new WinstonCloudWatch({
+  cloudWatchLogs: new AWS.CloudWatchLogs(),
+  logGroupName: 'testing',
+  logStreamName: 'first'
+}));
+
+```
+
 ### Options
 
 This is the list of options you could pass as argument to `winston.add`:
@@ -110,6 +127,7 @@ This is the list of options you could pass as argument to `winston.add`:
  * level - defaults to `info`
  * logGroupName - `string` or `function`
  * logStreamName - `string` or `function`
+ * cloudWatchLogs - `AWS.CloudWatchLogs` instance, used to set custom AWS instance. aws* and proxyServer options do not get used if this is set.
  * awsAccessKeyId
  * awsSecretKey
  * awsRegion

--- a/test/index.js
+++ b/test/index.js
@@ -53,6 +53,14 @@ describe('index', function() {
 
   describe('construtor', function() {
 
+    it('allows cloudWatchLogs', function() {
+      var options = {
+        cloudWatchLogs: { fakeOptions: { region: 'us-west-2' }}
+      };
+      var transport = new WinstonCloudWatch(options);
+      transport.cloudwatchlogs.fakeOptions.region.should.equal('us-west-2');
+    });
+
     it('allows awsOptions', function() {
       var options = {
         awsOptions: {

--- a/typescript/winston-cloudwatch.d.ts
+++ b/typescript/winston-cloudwatch.d.ts
@@ -47,6 +47,7 @@ declare namespace WinstonCloudwatch {
   export type LogObject = { level: string; msg: string; meta?: any };
 
   export interface CloudwatchTransportOptions {
+    cloudWatchLogs?: CloudWatchLogs,
     level?: string;
     logGroupName?: string | (() => string);
     logStreamName?: string | (() => string);


### PR DESCRIPTION
Fixes #57 

Went with just passing the AWS.CloudWatchLogs instance as that is the instance needed. 