### PR TITLE
Fix `LogObject` type declaration

### DIFF
--- a/typescript/winston-cloudwatch.d.ts
+++ b/typescript/winston-cloudwatch.d.ts
@@ -44,7 +44,7 @@ export = WinstonCloudwatch;
 // Declare optional exports
 declare namespace WinstonCloudwatch {
 
-  export type LogObject = { level: string; msg: string; meta?: any };
+  export type LogObject = { level: string; message: string; meta?: any };
 
   export interface CloudwatchTransportOptions {
     cloudWatchLogs?: CloudWatchLogs,


### PR DESCRIPTION
Hey, 
Thanks for the winston cloudwatch integration!  ☺️ 
Noticed that `LogObject` passed to `messageFormatter` has a `message` property instead of `msg`, so I fixed the type declaration.

