### PR TITLE
Include CloudWatch event limits

### DIFF
--- a/lib/cloudwatch-integration.js
+++ b/lib/cloudwatch-integration.js
@@ -1,7 +1,11 @@
 var LIMITS = {
   MAX_EVENT_MSG_SIZE_BYTES: 256000,   // The real max size is 262144, we leave some room for overhead on each message
   MAX_BATCH_SIZE_BYTES: 1000000,      // We leave some fudge factor here too.
-};
+}
+
+// CloudWatch adds 26 bytes per log event based on their documentation:
+// https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html
+var BASE_EVENT_SIZE_BYTES = 26;
 
 var find = require('lodash.find'),
     async = require('async'),
@@ -49,7 +53,7 @@ lib.upload = function(aws, groupName, streamName, logEvents, retentionInDays, cb
       while (entryIndex < logEvents.length) {
         var ev = logEvents[entryIndex];
         // unit tests pass null elements
-        var evSize = ev ? Buffer.byteLength(ev.message, 'utf8') : 0;
+        var evSize = ev ? Buffer.byteLength(ev.message, 'utf8') + BASE_EVENT_SIZE_BYTES : 0;
         if(evSize > LIMITS.MAX_EVENT_MSG_SIZE_BYTES) {
           evSize = LIMITS.MAX_EVENT_MSG_SIZE_BYTES;
           ev.message = ev.message.substring(0, evSize);

--- a/test/cloudwatch-integration.js
+++ b/test/cloudwatch-integration.js
@@ -92,10 +92,10 @@ describe('cloudwatch-integration', function() {
       ];
       lib.upload(aws, 'group', 'stream', events, 0, function(err) {
         aws.putLogEvents.calledOnce.should.equal(true);
-        aws.putLogEvents.args[0][0].logEvents.length.should.equal(4); // First Batch
+        aws.putLogEvents.args[0][0].logEvents.length.should.equal(3); // First Batch
         // Now, finish.
         lib.upload(aws, 'group', 'stream', events, 0, function(err) {
-          aws.putLogEvents.args[1][0].logEvents.length.should.equal(1); // Second Batch
+          aws.putLogEvents.args[1][0].logEvents.length.should.equal(2); // Second Batch
           done()
         });
       });


### PR DESCRIPTION
According to their documentation, "the maximum batch size is 1,048,576 bytes. This size is calculated as the sum of all event messages in UTF-8, plus 26 bytes for each log event." Currently we only include the first part of size calculation. This means that any batch with more than 1868 messages will fail with an invalid parameter error because we only allow 48,576 extra bytes. Now, we'll allow you to send batches with any number of events as long as they pass AWS's limits.