### PR TITLE
Allow skipping ensure loggroup

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ var WinstonCloudWatch = function(options) {
   this.logGroupName = options.logGroupName;
   this.retentionInDays = options.retentionInDays || 0;
   this.logStreamName = options.logStreamName;
+  this.options = options;
 
   var awsAccessKeyId = options.awsAccessKeyId;
   var awsSecretKey = options.awsSecretKey;
@@ -128,6 +129,7 @@ WinstonCloudWatch.prototype.submit = function(callback) {
     streamName,
     this.logEvents,
     retentionInDays,
+    this.options,
     callback
   );
 };

--- a/lib/cloudwatch-integration.js
+++ b/lib/cloudwatch-integration.js
@@ -15,7 +15,7 @@ var lib = {
   _postingEvents: {}
 };
 
-lib.upload = function(aws, groupName, streamName, logEvents, retentionInDays, cb) {
+lib.upload = function(aws, groupName, streamName, logEvents, retentionInDays, options, cb) {
   debug('upload', logEvents);
 
   // trying to send a batch before the last completed
@@ -41,7 +41,7 @@ lib.upload = function(aws, groupName, streamName, logEvents, retentionInDays, cb
   // go getToken() returns, without this check also here, it would attempt to send
   // an empty array, resulting in the InvalidParameterException.
   function safeUpload(cb) {
-    lib.getToken(aws, groupName, streamName, retentionInDays, function(err, token) {
+    lib.getToken(aws, groupName, streamName, retentionInDays, options, function(err, token) {
 
       if (err) {
         debug('error getting token', err, true);
@@ -83,7 +83,7 @@ lib.upload = function(aws, groupName, streamName, logEvents, retentionInDays, cb
           // for the group being set to null
           if (err.code === 'InvalidSequenceTokenException' || err.code === 'ResourceNotFoundException') {
             debug(err.code + ', retrying', true);
-            lib.submitWithAnotherToken(aws, groupName, streamName, payload, retentionInDays, cb)
+            lib.submitWithAnotherToken(aws, groupName, streamName, payload, retentionInDays, options, cb)
           } else {
             debug('error during putLogEvents', err, true)
             retrySubmit(aws, payload, 3, cb)
@@ -101,9 +101,9 @@ lib.upload = function(aws, groupName, streamName, logEvents, retentionInDays, cb
   }
 };
 
-lib.submitWithAnotherToken = function(aws, groupName, streamName, payload, retentionInDays, cb) {
+lib.submitWithAnotherToken = function(aws, groupName, streamName, payload, retentionInDays, options, cb) {
   lib._nextToken[previousKeyMapKey(groupName, streamName)] = null;
-  lib.getToken(aws, groupName, streamName, retentionInDays, function(err, token) {
+  lib.getToken(aws, groupName, streamName, retentionInDays, options, function(err, token) {
     payload.sequenceToken = token;
     aws.putLogEvents(payload, function(err) {
       lib._postingEvents[streamName] = false;
@@ -124,7 +124,7 @@ function retrySubmit(aws, payload, times, cb) {
   })
 }
 
-lib.getToken = function(aws, groupName, streamName, retentionInDays, cb) {
+lib.getToken = function(aws, groupName, streamName, retentionInDays, options, cb) {
   var existingNextToken = lib._nextToken[previousKeyMapKey(groupName, streamName)];
   if (existingNextToken != null) {
     debug('using existing next token and assuming exists', existingNextToken);
@@ -132,10 +132,14 @@ lib.getToken = function(aws, groupName, streamName, retentionInDays, cb) {
     return;
   }
 
-  async.series([
+  const calls = options.ensureLogGroup !== false ? [
     lib.ensureGroupPresent.bind(null, aws, groupName, retentionInDays),
     lib.getStream.bind(null, aws, groupName, streamName)
-  ], function(err, resources) {
+  ] : [
+    lib.getStream.bind(null, aws, groupName, streamName)
+  ];
+
+  async.series(calls, function(err, resources) {
     var groupPresent = resources[0],
         stream = resources[1];
     if (groupPresent && stream) {

--- a/lib/cloudwatch-integration.js
+++ b/lib/cloudwatch-integration.js
@@ -140,8 +140,8 @@ lib.getToken = function(aws, groupName, streamName, retentionInDays, options, cb
   ];
 
   async.series(calls, function(err, resources) {
-    var groupPresent = resources[0],
-        stream = resources[1];
+    var groupPresent = calls.length>1 ? resources[0] : true,
+        stream = calls.length === 1 ? resources[0] : resources[1];
     if (groupPresent && stream) {
       debug('token found', stream.uploadSequenceToken);
       cb(err, stream.uploadSequenceToken);

--- a/test/cloudwatch-integration.js
+++ b/test/cloudwatch-integration.js
@@ -29,8 +29,12 @@ describe('cloudwatch-integration', function() {
       const events = [{ message : "test message", timestamp : new Date().toISOString()}];
       aws.putLogEvents.onFirstCall().returns(); // Don't call call back to simulate ongoing request.
       aws.putLogEvents.onSecondCall().yields();
-      lib.upload(aws, 'group', 'stream', events, 0, function(){});
-      lib.upload(aws, 'group', 'stream', events, 0, function() {
+      lib.upload(aws, 'group', 'stream', events, 0, {
+        ensureGroupPresent: true
+      }, function(){});
+      lib.upload(aws, 'group', 'stream', events, 0, {
+        ensureGroupPresent: true
+      }, function() {
         // The second upload call should get ignored
         aws.putLogEvents.calledOnce.should.equal(true);
         lib._postingEvents['stream'] = false; // reset
@@ -42,8 +46,12 @@ describe('cloudwatch-integration', function() {
       const events = [{ message : "test message", timestamp : new Date().toISOString()}];
       lib.getToken.onFirstCall().returns(); // Don't call call back to simulate ongoing token request.
       lib.getToken.onSecondCall().yields(null, 'token');
-      lib.upload(aws, 'group', 'stream', events, 0, function(){});
-      lib.upload(aws, 'group', 'stream', events, 0, function() {
+      lib.upload(aws, 'group', 'stream', events, 0, {
+        ensureGroupPresent: true
+      }, function(){});
+      lib.upload(aws, 'group', 'stream', events, 0, {
+        ensureGroupPresent: true
+      }, function() {
         // The second upload call should get ignored
         lib.getToken.calledOnce.should.equal(true);
         lib._postingEvents['stream'] = false; // reset
@@ -55,8 +63,12 @@ describe('cloudwatch-integration', function() {
       const events = [{ message : "test message", timestamp : new Date().toISOString()}];
       lib.getToken.onFirstCall().returns(); // Don't call call back to simulate ongoing token request.
       lib.getToken.onSecondCall().yields(null, 'token');
-      lib.upload(aws, 'group', 'stream1', events, 0, function(){ });
-      lib.upload(aws, 'group', 'stream2', events, 0, function(){ done() });
+      lib.upload(aws, 'group', 'stream1', events, 0, {
+        ensureGroupPresent: true
+      }, function(){ });
+      lib.upload(aws, 'group', 'stream2', events, 0, {
+        ensureGroupPresent: true
+      }, function(){ done() });
 
       lib.getToken.calledTwice.should.equal(true);
 
@@ -68,7 +80,11 @@ describe('cloudwatch-integration', function() {
       var BIG_MSG_LEN = 300000;
       const events = [{ message : new Array(BIG_MSG_LEN).join('A'), timestamp : new Date().toISOString()}];
       var errCalled = false;
-      lib.upload(aws, 'group', 'stream', events, 0, function(err) {
+      lib.upload(aws, 'group', 'stream', events, {
+        ensureGroupPresent: true
+      }, 0, {
+        ensureGroupPresent: true
+      }, function(err) {
         if(err) {
           errCalled = true;
           return;
@@ -90,11 +106,15 @@ describe('cloudwatch-integration', function() {
         { message : bigMessage, timestamp : new Date().toISOString()},
         { message : bigMessage, timestamp : new Date().toISOString()}
       ];
-      lib.upload(aws, 'group', 'stream', events, 0, function(err) {
+      lib.upload(aws, 'group', 'stream', events, 0, {
+        ensureGroupPresent: true
+      }, function(err) {
         aws.putLogEvents.calledOnce.should.equal(true);
         aws.putLogEvents.args[0][0].logEvents.length.should.equal(3); // First Batch
         // Now, finish.
-        lib.upload(aws, 'group', 'stream', events, 0, function(err) {
+        lib.upload(aws, 'group', 'stream', events, 0, {
+          ensureGroupPresent: true
+        }, function(err) {
           aws.putLogEvents.args[1][0].logEvents.length.should.equal(2); // Second Batch
           done()
         });
@@ -102,7 +122,9 @@ describe('cloudwatch-integration', function() {
     });
 
     it('puts log events', function(done) {
-      lib.upload(aws, 'group', 'stream', Array(20), 0, function() {
+      lib.upload(aws, 'group', 'stream', Array(20), 0, {
+        ensureGroupPresent: true
+      }, function() {
         aws.putLogEvents.calledOnce.should.equal(true);
         aws.putLogEvents.args[0][0].logGroupName.should.equal('group');
         aws.putLogEvents.args[0][0].logStreamName.should.equal('stream');
@@ -114,7 +136,9 @@ describe('cloudwatch-integration', function() {
 
     it('adds token to the payload only if it exists', function(done) {
       lib.getToken.yields(null);
-      lib.upload(aws, 'group', 'stream', Array(20), 0, function() {
+      lib.upload(aws, 'group', 'stream', Array(20), {
+        ensureGroupPresent: true
+      }, 0, function() {
         aws.putLogEvents.calledOnce.should.equal(true);
         aws.putLogEvents.args[0][0].logGroupName.should.equal('group');
         aws.putLogEvents.args[0][0].logStreamName.should.equal('stream');
@@ -125,7 +149,9 @@ describe('cloudwatch-integration', function() {
     });
 
     it('does not put if events are empty', function(done) {
-      lib.upload(aws, 'group', 'stream', [], 0, function() {
+      lib.upload(aws, 'group', 'stream', [], 0, {
+        ensureGroupPresent: true
+      }, function() {
         aws.putLogEvents.called.should.equal(false);
         done();
       });
@@ -133,7 +159,9 @@ describe('cloudwatch-integration', function() {
 
     it('errors if getting the token errors', function(done) {
       lib.getToken.yields('err');
-      lib.upload(aws, 'group', 'stream', Array(20), 0, function(err) {
+      lib.upload(aws, 'group', 'stream', Array(20), 0, {
+        ensureGroupPresent: true
+      }, function(err) {
         err.should.equal('err');
         done();
       });
@@ -141,7 +169,9 @@ describe('cloudwatch-integration', function() {
 
     it('errors if putting log events errors', function(done) {
       aws.putLogEvents.yields('err');
-      lib.upload(aws, 'group', 'stream', Array(20), 0, function(err) {
+      lib.upload(aws, 'group', 'stream', Array(20), 0, {
+        ensureGroupPresent: true
+      }, function(err) {
         err.should.equal('err');
         done();
       });
@@ -149,7 +179,9 @@ describe('cloudwatch-integration', function() {
 
     it('gets another token if InvalidSequenceTokenException', function(done) {
       aws.putLogEvents.yields({ code: 'InvalidSequenceTokenException' });
-      lib.upload(aws, 'group', 'stream', Array(20), 0, function(err) {
+      lib.upload(aws, 'group', 'stream', Array(20), 0, {
+        ensureGroupPresent: true
+      }, function(err) {
         lib.submitWithAnotherToken.calledOnce.should.equal(true);
         done();
       });
@@ -157,7 +189,9 @@ describe('cloudwatch-integration', function() {
 
     it('gets another token if ResourceNotFoundException', function(done) {
       aws.putLogEvents.yields({ code: 'InvalidSequenceTokenException' });
-      lib.upload(aws, 'group', 'stream', Array(20), 0, function(err) {
+      lib.upload(aws, 'group', 'stream', Array(20), 0, {
+        ensureGroupPresent: true
+      }, function(err) {
         lib.submitWithAnotherToken.calledOnce.should.equal(true);
         done();
       });
@@ -166,7 +200,9 @@ describe('cloudwatch-integration', function() {
     it('nextToken is saved when available', function(done) {
       var nextSequenceToken = 'abc123';
       aws.putLogEvents.yields(null, { nextSequenceToken: nextSequenceToken });
-      lib.upload(aws, 'group', 'stream', Array(20), 0, function() {
+      lib.upload(aws, 'group', 'stream', Array(20), 0, {
+        ensureGroupPresent: true
+      }, function() {
         sinon.assert.match(lib._nextToken, { 'group:stream': nextSequenceToken });
         done();
       });
@@ -203,7 +239,9 @@ describe('cloudwatch-integration', function() {
     });
 
     it('ensures group and stream are present if no nextToken for group/stream', function(done) {
-      lib.getToken(aws, 'group', 'stream', 0, function() {
+      lib.getToken(aws, 'group', 'stream', 0, {
+        ensureGroupPresent: true
+      }, function() {
         lib.ensureGroupPresent.calledOnce.should.equal(true);
         lib.getStream.calledOnce.should.equal(true);
         done();
@@ -215,7 +253,9 @@ describe('cloudwatch-integration', function() {
       lib.getStream.yields(null, {
         uploadSequenceToken: 'token'
       });
-      lib.getToken(aws, 'group', 'stream', 0, function(err, token) {
+      lib.getToken(aws, 'group', 'stream', 0, {
+        ensureGroupPresent: true
+      }, function(err, token) {
         should.not.exist(err);
         token.should.equal('token');
         done();
@@ -224,7 +264,9 @@ describe('cloudwatch-integration', function() {
 
     it('errors when ensuring group errors', function(done) {
       lib.ensureGroupPresent.yields('err');
-      lib.getToken(aws, 'group', 'stream', 0, function(err) {
+      lib.getToken(aws, 'group', 'stream', 0, {
+        ensureGroupPresent: true
+      }, function(err) {
         err.should.equal('err');
         done();
       });
@@ -232,7 +274,9 @@ describe('cloudwatch-integration', function() {
 
     it('errors when ensuring stream errors', function(done) {
       lib.getStream.yields('err');
-      lib.getToken(aws, 'group', 'stream', 0, function(err) {
+      lib.getToken(aws, 'group', 'stream', 0, {
+        ensureGroupPresent: true
+      }, function(err) {
         err.should.equal('err');
         done();
       });
@@ -240,7 +284,9 @@ describe('cloudwatch-integration', function() {
 
     it('does not ensure group and stream are present if nextToken for group/stream', function(done) {
       lib._nextToken = { 'group:stream': 'test123' };
-      lib.getToken(aws, 'group', 'stream', 0, function() {
+      lib.getToken(aws, 'group', 'stream', 0, {
+        ensureGroupPresent: true
+      }, function() {
         lib.ensureGroupPresent.notCalled.should.equal(true);
         lib.getStream.notCalled.should.equal(true);
         done();
@@ -469,7 +515,9 @@ describe('cloudwatch-integration', function() {
     });
 
     it('gets a token then resubmits', function(done) {
-      lib.submitWithAnotherToken(aws, 'group', 'stream', {}, 0, function() {
+      lib.submitWithAnotherToken(aws, 'group', 'stream', {}, 0,{
+        ensureGroupPresent: true
+      }, function() {
         aws.putLogEvents.calledOnce.should.equal(true);
         aws.putLogEvents.args[0][0].sequenceToken.should.equal('new-token');
         done();

--- a/test/cloudwatch-integration.js
+++ b/test/cloudwatch-integration.js
@@ -80,9 +80,7 @@ describe('cloudwatch-integration', function() {
       var BIG_MSG_LEN = 300000;
       const events = [{ message : new Array(BIG_MSG_LEN).join('A'), timestamp : new Date().toISOString()}];
       var errCalled = false;
-      lib.upload(aws, 'group', 'stream', events, {
-        ensureGroupPresent: true
-      }, 0, {
+      lib.upload(aws, 'group', 'stream', events, 0, {
         ensureGroupPresent: true
       }, function(err) {
         if(err) {

--- a/test/index.js
+++ b/test/index.js
@@ -17,7 +17,7 @@ describe('index', function() {
     }
   };
   var stubbedCloudwatchIntegration = {
-    upload: sinon.spy(function(aws, groupName, streamName, logEvents, retention, cb) {
+    upload: sinon.spy(function(aws, groupName, streamName, logEvents, retention, options, cb) {
       this.lastLoggedEvents = logEvents.splice(0, 20);
       cb();
     })

--- a/typescript/winston-cloudwatch.d.ts
+++ b/typescript/winston-cloudwatch.d.ts
@@ -13,6 +13,7 @@ declare class WinstonCloudwatch extends TransportStream {
     streamName: string,
     logEvents: any[],
     retentionInDays: number,
+    options: WinstonCloudwatch.CloudwatchTransportOptions,
     cb: ((err: Error, data: any) => void)
   ): void;
   getToken(
@@ -20,6 +21,7 @@ declare class WinstonCloudwatch extends TransportStream {
     groupName: string,
     streamName: string,
     retentionInDays: number,
+    options: WinstonCloudwatch.CloudwatchTransportOptions,
     cb: ((err: Error, data: string) => void)
   ): void;
   ensureGroupPresent(
@@ -51,6 +53,7 @@ declare namespace WinstonCloudwatch {
   export interface CloudwatchTransportOptions {
     cloudWatchLogs?: CloudWatchLogs,
     level?: string;
+    ensureLogGroup?: boolean;
     logGroupName?: string | (() => string);
     logStreamName?: string | (() => string);
     awsAccessKeyId?: string;


### PR DESCRIPTION
This could help to have only 1 DescribeLog calls instead of 2 if a user is sure that loggroup is present