### PR TITLE
Update Logs Limit Doc to correct URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Remember to install types for both winston and this library.
 ### Usage
 
 Please refer to [AWS CloudWatch Logs documentation](http://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html) for possible contraints that might affect you.
-Also have a look at [AWS CloudWatch Logs limits](http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/cloudwatch_limits.html).
+Also have a look at [AWS CloudWatch Logs limits](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/cloudwatch_limits_cwl.html).
 
 In ES5
 ```js


### PR DESCRIPTION
The previous URL showed general metric limits without anything regarding logs.

Have updated the README to go to the Log specific limits, as mentioned further down the page within the options section.