### PR TITLE
Fix package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,7 @@
 {
   "name": "winston-cloudwatch",
   "version": "2.5.2",
-<<<<<<< HEAD
   "lockfileVersion": 2,
-=======
-  "lockfileVersion": 1,
->>>>>>> 94e3e43df5e6d16a4fe741cb3929f17d5b316601
   "requires": true,
   "packages": {
     "": {


### PR DESCRIPTION
There was a merge conflict marker committed to the `package-lock.json` in  cc0de4ba5063bb60eb148be3ce1bd3e92c64b005, which coincidentally upgraded the project to use `lockfileVersion` of `2`.