### PR TITLE
Fix: Create log groups when missing

### DIFF
--- a/lib/cloudwatch-integration.js
+++ b/lib/cloudwatch-integration.js
@@ -81,7 +81,7 @@ lib.upload = function(aws, groupName, streamName, logEvents, retentionInDays, op
           // InvalidSequenceToken means we need to do a describe to get another token
           // also do the same if ResourceNotFound as that will result in the last token
           // for the group being set to null
-          if (err.code === 'InvalidSequenceTokenException' || err.code === 'ResourceNotFoundException') {
+          if (err.name === 'InvalidSequenceTokenException' || err.name === 'ResourceNotFoundException') {
             debug(err.name + ', retrying', true);
             lib.submitWithAnotherToken(aws, groupName, streamName, payload, retentionInDays, options, cb)
           } else {
@@ -162,7 +162,7 @@ lib.ensureGroupPresent = function ensureGroupPresent(aws, name, retentionInDays,
   var params = { logGroupName: name };
   aws.describeLogStreams(params, function(err, data) {
     // TODO we should cb(err, false) if there's an error?
-    if (err && err.code == 'ResourceNotFoundException') {
+    if (err && err.name == 'ResourceNotFoundException') {
       debug('create group');
       return aws.createLogGroup(params, lib.ignoreInProgress(function(err) {
         if(!err) lib.putRetentionPolicy(aws, name, retentionInDays);
@@ -219,8 +219,8 @@ lib.getStream = function getStream(aws, groupName, streamName, cb) {
 
 lib.ignoreInProgress = function ignoreInProgress(cb) {
   return function(err, data) {
-    if (err && (err.code == 'OperationAbortedException' ||
-                err.code == 'ResourceAlreadyExistsException')) {
+    if (err && (err.name == 'OperationAbortedException' ||
+                err.name == 'ResourceAlreadyExistsException')) {
       debug('ignore operation in progress', err.message);
       cb(null, data);
     } else {

--- a/test/cloudwatch-integration.js
+++ b/test/cloudwatch-integration.js
@@ -176,7 +176,7 @@ describe('cloudwatch-integration', function() {
     });
 
     it('gets another token if InvalidSequenceTokenException', function(done) {
-      aws.putLogEvents.yields({ code: 'InvalidSequenceTokenException' });
+      aws.putLogEvents.yields({ name: 'InvalidSequenceTokenException' });
       lib.upload(aws, 'group', 'stream', Array(20), 0, {
         ensureGroupPresent: true
       }, function(err) {
@@ -186,7 +186,7 @@ describe('cloudwatch-integration', function() {
     });
 
     it('gets another token if ResourceNotFoundException', function(done) {
-      aws.putLogEvents.yields({ code: 'InvalidSequenceTokenException' });
+      aws.putLogEvents.yields({ name: 'InvalidSequenceTokenException' });
       lib.upload(aws, 'group', 'stream', Array(20), 0, {
         ensureGroupPresent: true
       }, function(err) {
@@ -315,7 +315,7 @@ describe('cloudwatch-integration', function() {
     });
 
     it('creates a group if it is not present', function(done) {
-      var err = { code: 'ResourceNotFoundException' };
+      var err = { name: 'ResourceNotFoundException' };
       aws.describeLogStreams = sinon.stub().yields(err);
       aws.createLogGroup = sinon.stub().yields(null);
 
@@ -337,7 +337,7 @@ describe('cloudwatch-integration', function() {
     });
 
     it('errors if creating a group errors', function(done) {
-      var err = { code: 'ResourceNotFoundException' };
+      var err = { name: 'ResourceNotFoundException' };
       aws.describeLogStreams = sinon.stub().yields(err);
       aws.createLogGroup = sinon.stub().yields('err');
 
@@ -411,7 +411,7 @@ describe('cloudwatch-integration', function() {
             logStreamName: 'another-stream'
           }]
         });
-      var err = { code: 'OperationAbortedException' };
+      var err = { name: 'OperationAbortedException' };
       aws.createLogStream = sinon.stub().yields(err);
 
       lib.getStream(aws, 'group', 'stream', function(err, stream) {
@@ -432,7 +432,7 @@ describe('cloudwatch-integration', function() {
             logStreamName: 'another-stream'
           }]
         });
-      err = { code: 'ResourceAlreadyExistsException' };
+      err = { name: 'ResourceAlreadyExistsException' };
       aws.createLogStream = sinon.stub().yields(err);
 
       lib.getStream(aws, 'group', 'stream', function(err, stream) {
@@ -460,7 +460,7 @@ describe('cloudwatch-integration', function() {
 
     it('ignores a OperationAbortedException', function(done) {
       function runner(cb) {
-        var err = { code: 'OperationAbortedException' };
+        var err = { name: 'OperationAbortedException' };
         cb(err);
       }
 
@@ -472,7 +472,7 @@ describe('cloudwatch-integration', function() {
 
     it('ignores a ResourceAlreadyExistsException', function(done) {
       function runner(cb) {
-        var err = { code: 'ResourceAlreadyExistsException' };
+        var err = { name: 'ResourceAlreadyExistsException' };
         cb(err);
       }
 


### PR DESCRIPTION
## Overview

When the ensureLogGroup option is true, the log group will be created if it is missing.

## Changes

Use err.name instead of err.code for AWS errors. This appears to be a consequence of using @aws-sdk (v3) instead of aws-sdk (v2).