### PR TITLE
Add @aws-sdk/client-cloudwatch-logs as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "license": "MIT",
   "typings": "typescript/winston-cloudwatch.d.ts",
   "peerDependencies": {
+    "@aws-sdk/client-cloudwatch-logs": "^3.0.0",
     "winston": "^3.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
Adding @aws-sdk/client-cloudwatch-logs  as a peer dependency will ensure Serverless includes that package when it is bundling/tree shaking