### PR TITLE
Add error parameter to kthxbye callback

### DIFF
--- a/typescript/winston-cloudwatch.d.ts
+++ b/typescript/winston-cloudwatch.d.ts
@@ -6,7 +6,7 @@ import winston = require("winston");
 
 // Declare the default WinstonCloudwatch class
 declare class WinstonCloudwatch extends TransportStream {
-  kthxbye(callback: () => void): void;
+  kthxbye(callback: (err: Error) => void): void;
   upload(
     aws: CloudWatchLogs,
     groupName: string,


### PR DESCRIPTION
Add error parameter to `kthxbye` callback function to allow better error handling when using TypeScript.

#187 