### PR TITLE
Add @aws-sdk/client-cloudwatch-logs to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "winston-cloudwatch",
-  "version": "4.0.0",
+  "version": "6.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8,6 +8,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.0.tgz",
       "integrity": "sha512-pkVXf/dq6PITJ0jzYZ69VhL8VFOFoPZLZqtU/12SGnzYuJOOGNfF41q9GxdI1yqC8R13Rq3jOLKDFpUJFT5eTA==",
+      "dev": true,
       "requires": {
         "tslib": "^1.11.1"
       },
@@ -15,7 +16,8 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
         }
       }
     },
@@ -23,6 +25,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
       "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+      "dev": true,
       "requires": {
         "@aws-crypto/ie11-detection": "^2.0.0",
         "@aws-crypto/sha256-js": "^2.0.0",
@@ -37,7 +40,8 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
         }
       }
     },
@@ -45,6 +49,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
       "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+      "dev": true,
       "requires": {
         "@aws-crypto/util": "^2.0.0",
         "@aws-sdk/types": "^3.1.0",
@@ -54,7 +59,8 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
         }
       }
     },
@@ -62,6 +68,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.0.tgz",
       "integrity": "sha512-Ge7WQ3E0OC7FHYprsZV3h0QIcpdyJLvIeg+uTuHqRYm8D6qCFJoiC+edSzSyFiHtZf+NOQDJ1q46qxjtzIY2nA==",
+      "dev": true,
       "requires": {
         "tslib": "^1.11.1"
       },
@@ -69,7 +76,8 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
         }
       }
     },
@@ -77,6 +85,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.1.tgz",
       "integrity": "sha512-JJmFFwvbm08lULw4Nm5QOLg8+lAQeC8aCXK5xrtxntYzYXCGfHwUJ4Is3770Q7HmICsXthGQ+ZsDL7C2uH3yBQ==",
+      "dev": true,
       "requires": {
         "@aws-sdk/types": "^3.1.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -86,611 +95,676 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
         }
       }
     },
     "@aws-sdk/abort-controller": {
-      "version": "3.54.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.54.1.tgz",
-      "integrity": "sha512-yYrZ4iFZzxxx6w14WbSCL157lkoFuSfLroCswb9fV9oVfEoHRL3a4MV/7SkbK3e3LtHiJ33tLFO15kmMYIEnLA==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.78.0.tgz",
+      "integrity": "sha512-iz1YLwM2feJUj/y97yO4XmDeTxs+yZ1XJwQgoawKuc8IDBKUutnJNCHL5jL04WUKU7Nrlq+Hr2fCTScFh2z9zg==",
+      "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.54.1",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/client-cloudwatch-logs": {
-      "version": "3.54.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch-logs/-/client-cloudwatch-logs-3.54.1.tgz",
-      "integrity": "sha512-CReaB7XJ7C59Cfmsq7aTAs/QlucFlVwk57r9RJZXw2psr6vSbcFpZRmkqVnGTh8tsaAMXa7mX3XDLE3REm0eUQ==",
+      "version": "3.85.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch-logs/-/client-cloudwatch-logs-3.85.0.tgz",
+      "integrity": "sha512-Q3Isl5AFjOJ1N2/loQlZ8jhbdCFMxMEX9lvsBvLDsywOYWwXWNVEdvTYwu7haPoDKjK8fq+dqN0lbfMqKWHoeg==",
+      "dev": true,
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.54.1",
-        "@aws-sdk/config-resolver": "3.54.1",
-        "@aws-sdk/credential-provider-node": "3.54.1",
-        "@aws-sdk/fetch-http-handler": "3.54.1",
-        "@aws-sdk/hash-node": "3.54.1",
-        "@aws-sdk/invalid-dependency": "3.54.1",
-        "@aws-sdk/middleware-content-length": "3.54.1",
-        "@aws-sdk/middleware-host-header": "3.54.1",
-        "@aws-sdk/middleware-logger": "3.54.1",
-        "@aws-sdk/middleware-retry": "3.54.1",
-        "@aws-sdk/middleware-serde": "3.54.1",
-        "@aws-sdk/middleware-signing": "3.54.1",
-        "@aws-sdk/middleware-stack": "3.54.1",
-        "@aws-sdk/middleware-user-agent": "3.54.1",
-        "@aws-sdk/node-config-provider": "3.54.1",
-        "@aws-sdk/node-http-handler": "3.54.1",
-        "@aws-sdk/protocol-http": "3.54.1",
-        "@aws-sdk/smithy-client": "3.54.1",
-        "@aws-sdk/types": "3.54.1",
-        "@aws-sdk/url-parser": "3.54.1",
-        "@aws-sdk/util-base64-browser": "3.52.0",
-        "@aws-sdk/util-base64-node": "3.52.0",
-        "@aws-sdk/util-body-length-browser": "3.54.0",
-        "@aws-sdk/util-body-length-node": "3.54.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.54.1",
-        "@aws-sdk/util-defaults-mode-node": "3.54.1",
-        "@aws-sdk/util-user-agent-browser": "3.54.1",
-        "@aws-sdk/util-user-agent-node": "3.54.1",
-        "@aws-sdk/util-utf8-browser": "3.52.0",
-        "@aws-sdk/util-utf8-node": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/client-sts": "3.85.0",
+        "@aws-sdk/config-resolver": "3.80.0",
+        "@aws-sdk/credential-provider-node": "3.85.0",
+        "@aws-sdk/fetch-http-handler": "3.78.0",
+        "@aws-sdk/hash-node": "3.78.0",
+        "@aws-sdk/invalid-dependency": "3.78.0",
+        "@aws-sdk/middleware-content-length": "3.78.0",
+        "@aws-sdk/middleware-host-header": "3.78.0",
+        "@aws-sdk/middleware-logger": "3.78.0",
+        "@aws-sdk/middleware-retry": "3.80.0",
+        "@aws-sdk/middleware-serde": "3.78.0",
+        "@aws-sdk/middleware-signing": "3.78.0",
+        "@aws-sdk/middleware-stack": "3.78.0",
+        "@aws-sdk/middleware-user-agent": "3.78.0",
+        "@aws-sdk/node-config-provider": "3.80.0",
+        "@aws-sdk/node-http-handler": "3.82.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/smithy-client": "3.85.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/url-parser": "3.78.0",
+        "@aws-sdk/util-base64-browser": "3.58.0",
+        "@aws-sdk/util-base64-node": "3.55.0",
+        "@aws-sdk/util-body-length-browser": "3.55.0",
+        "@aws-sdk/util-body-length-node": "3.55.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.85.0",
+        "@aws-sdk/util-defaults-mode-node": "3.85.0",
+        "@aws-sdk/util-user-agent-browser": "3.78.0",
+        "@aws-sdk/util-user-agent-node": "3.80.0",
+        "@aws-sdk/util-utf8-browser": "3.55.0",
+        "@aws-sdk/util-utf8-node": "3.55.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/client-sso": {
-      "version": "3.54.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.54.1.tgz",
-      "integrity": "sha512-Ir6XG8EzbfUVqr97rkEMW7eFGByiKQGv1Oc7Nxl3BqSXYD35rP2IJ/HI5TXx+CgOY+Ov+bI3g5BZZvSCXd3OBg==",
+      "version": "3.85.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.85.0.tgz",
+      "integrity": "sha512-JMW0NzFpo99oE6O9M/kgLela73p4vmhe/5TIcdrqUvP9XUV9nANl5nSXh3rqLz0ubmliedz9kdYYhwMC3ntoXg==",
+      "dev": true,
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.54.1",
-        "@aws-sdk/fetch-http-handler": "3.54.1",
-        "@aws-sdk/hash-node": "3.54.1",
-        "@aws-sdk/invalid-dependency": "3.54.1",
-        "@aws-sdk/middleware-content-length": "3.54.1",
-        "@aws-sdk/middleware-host-header": "3.54.1",
-        "@aws-sdk/middleware-logger": "3.54.1",
-        "@aws-sdk/middleware-retry": "3.54.1",
-        "@aws-sdk/middleware-serde": "3.54.1",
-        "@aws-sdk/middleware-stack": "3.54.1",
-        "@aws-sdk/middleware-user-agent": "3.54.1",
-        "@aws-sdk/node-config-provider": "3.54.1",
-        "@aws-sdk/node-http-handler": "3.54.1",
-        "@aws-sdk/protocol-http": "3.54.1",
-        "@aws-sdk/smithy-client": "3.54.1",
-        "@aws-sdk/types": "3.54.1",
-        "@aws-sdk/url-parser": "3.54.1",
-        "@aws-sdk/util-base64-browser": "3.52.0",
-        "@aws-sdk/util-base64-node": "3.52.0",
-        "@aws-sdk/util-body-length-browser": "3.54.0",
-        "@aws-sdk/util-body-length-node": "3.54.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.54.1",
-        "@aws-sdk/util-defaults-mode-node": "3.54.1",
-        "@aws-sdk/util-user-agent-browser": "3.54.1",
-        "@aws-sdk/util-user-agent-node": "3.54.1",
-        "@aws-sdk/util-utf8-browser": "3.52.0",
-        "@aws-sdk/util-utf8-node": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/config-resolver": "3.80.0",
+        "@aws-sdk/fetch-http-handler": "3.78.0",
+        "@aws-sdk/hash-node": "3.78.0",
+        "@aws-sdk/invalid-dependency": "3.78.0",
+        "@aws-sdk/middleware-content-length": "3.78.0",
+        "@aws-sdk/middleware-host-header": "3.78.0",
+        "@aws-sdk/middleware-logger": "3.78.0",
+        "@aws-sdk/middleware-retry": "3.80.0",
+        "@aws-sdk/middleware-serde": "3.78.0",
+        "@aws-sdk/middleware-stack": "3.78.0",
+        "@aws-sdk/middleware-user-agent": "3.78.0",
+        "@aws-sdk/node-config-provider": "3.80.0",
+        "@aws-sdk/node-http-handler": "3.82.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/smithy-client": "3.85.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/url-parser": "3.78.0",
+        "@aws-sdk/util-base64-browser": "3.58.0",
+        "@aws-sdk/util-base64-node": "3.55.0",
+        "@aws-sdk/util-body-length-browser": "3.55.0",
+        "@aws-sdk/util-body-length-node": "3.55.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.85.0",
+        "@aws-sdk/util-defaults-mode-node": "3.85.0",
+        "@aws-sdk/util-user-agent-browser": "3.78.0",
+        "@aws-sdk/util-user-agent-node": "3.80.0",
+        "@aws-sdk/util-utf8-browser": "3.55.0",
+        "@aws-sdk/util-utf8-node": "3.55.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/client-sts": {
-      "version": "3.54.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.54.1.tgz",
-      "integrity": "sha512-1wgOvyyQcrNeeNWX2aerLOFb2+wkHeo9kjyErUJv7NLRzQGlFXmljfNme2ydvyUMA8NCwjEjePSfmktjnGP9BA==",
+      "version": "3.85.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.85.0.tgz",
+      "integrity": "sha512-qjaoGG1FrCTS1zSk/XOQRZ0v0JXeytpMl/hf6BcoX/NsaJzDaE5oJlzqdNGwd+1kLYt9J2igG3zxYgvxnCHg6w==",
+      "dev": true,
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.54.1",
-        "@aws-sdk/credential-provider-node": "3.54.1",
-        "@aws-sdk/fetch-http-handler": "3.54.1",
-        "@aws-sdk/hash-node": "3.54.1",
-        "@aws-sdk/invalid-dependency": "3.54.1",
-        "@aws-sdk/middleware-content-length": "3.54.1",
-        "@aws-sdk/middleware-host-header": "3.54.1",
-        "@aws-sdk/middleware-logger": "3.54.1",
-        "@aws-sdk/middleware-retry": "3.54.1",
-        "@aws-sdk/middleware-sdk-sts": "3.54.1",
-        "@aws-sdk/middleware-serde": "3.54.1",
-        "@aws-sdk/middleware-signing": "3.54.1",
-        "@aws-sdk/middleware-stack": "3.54.1",
-        "@aws-sdk/middleware-user-agent": "3.54.1",
-        "@aws-sdk/node-config-provider": "3.54.1",
-        "@aws-sdk/node-http-handler": "3.54.1",
-        "@aws-sdk/protocol-http": "3.54.1",
-        "@aws-sdk/smithy-client": "3.54.1",
-        "@aws-sdk/types": "3.54.1",
-        "@aws-sdk/url-parser": "3.54.1",
-        "@aws-sdk/util-base64-browser": "3.52.0",
-        "@aws-sdk/util-base64-node": "3.52.0",
-        "@aws-sdk/util-body-length-browser": "3.54.0",
-        "@aws-sdk/util-body-length-node": "3.54.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.54.1",
-        "@aws-sdk/util-defaults-mode-node": "3.54.1",
-        "@aws-sdk/util-user-agent-browser": "3.54.1",
-        "@aws-sdk/util-user-agent-node": "3.54.1",
-        "@aws-sdk/util-utf8-browser": "3.52.0",
-        "@aws-sdk/util-utf8-node": "3.52.0",
+        "@aws-sdk/config-resolver": "3.80.0",
+        "@aws-sdk/credential-provider-node": "3.85.0",
+        "@aws-sdk/fetch-http-handler": "3.78.0",
+        "@aws-sdk/hash-node": "3.78.0",
+        "@aws-sdk/invalid-dependency": "3.78.0",
+        "@aws-sdk/middleware-content-length": "3.78.0",
+        "@aws-sdk/middleware-host-header": "3.78.0",
+        "@aws-sdk/middleware-logger": "3.78.0",
+        "@aws-sdk/middleware-retry": "3.80.0",
+        "@aws-sdk/middleware-sdk-sts": "3.78.0",
+        "@aws-sdk/middleware-serde": "3.78.0",
+        "@aws-sdk/middleware-signing": "3.78.0",
+        "@aws-sdk/middleware-stack": "3.78.0",
+        "@aws-sdk/middleware-user-agent": "3.78.0",
+        "@aws-sdk/node-config-provider": "3.80.0",
+        "@aws-sdk/node-http-handler": "3.82.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/smithy-client": "3.85.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/url-parser": "3.78.0",
+        "@aws-sdk/util-base64-browser": "3.58.0",
+        "@aws-sdk/util-base64-node": "3.55.0",
+        "@aws-sdk/util-body-length-browser": "3.55.0",
+        "@aws-sdk/util-body-length-node": "3.55.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.85.0",
+        "@aws-sdk/util-defaults-mode-node": "3.85.0",
+        "@aws-sdk/util-user-agent-browser": "3.78.0",
+        "@aws-sdk/util-user-agent-node": "3.80.0",
+        "@aws-sdk/util-utf8-browser": "3.55.0",
+        "@aws-sdk/util-utf8-node": "3.55.0",
         "entities": "2.2.0",
         "fast-xml-parser": "3.19.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/config-resolver": {
-      "version": "3.54.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.54.1.tgz",
-      "integrity": "sha512-MPaahgP+WGdZDfvsrjiOcpdyIIt4XaT2d62x0DYhkeWR7q6/g5d73ynS9377AwVp+6LyjzisqX1lSjfUkG2ryQ==",
+      "version": "3.80.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.80.0.tgz",
+      "integrity": "sha512-vFruNKlmhsaC8yjnHmasi1WW/7EELlEuFTj4mqcqNqR4dfraf0maVvpqF1VSR8EstpFMsGYI5dmoWAnnG4PcLQ==",
+      "dev": true,
       "requires": {
-        "@aws-sdk/signature-v4": "3.54.1",
-        "@aws-sdk/types": "3.54.1",
-        "@aws-sdk/util-config-provider": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/signature-v4": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-config-provider": "3.55.0",
+        "@aws-sdk/util-middleware": "3.78.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-env": {
-      "version": "3.54.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.54.1.tgz",
-      "integrity": "sha512-+4ik84tPG6st6DxwymiJ/kO8OJPNjv0fROH4+OupvYiVyBLrvqoivbtwsee9mcQJ3KLkcASdht7bw271sP9wng==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.78.0.tgz",
+      "integrity": "sha512-K41VTIzVHm2RyIwtBER8Hte3huUBXdV1WKO+i7olYVgLFmaqcZUNrlyoGDRqZcQ/u4AbxTzBU9jeMIbIfzMOWg==",
+      "dev": true,
       "requires": {
-        "@aws-sdk/property-provider": "3.54.1",
-        "@aws-sdk/types": "3.54.1",
-        "tslib": "^2.3.0"
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-imds": {
-      "version": "3.54.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.54.1.tgz",
-      "integrity": "sha512-IIJ9Or9HAxdOzhXMEB1OBUc1EXLiNPd1BD30u5mEpyaO4jJf0AKNNg7Lkhnl5yDX0oY8pbaakDFVomqGt2c9aQ==",
+      "version": "3.81.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.81.0.tgz",
+      "integrity": "sha512-BHopP+gaovTYj+4tSrwCk8NNCR48gE9CWmpIOLkP9ell0gOL81Qh7aCEiIK0BZBZkccv1s16cYq1MSZZGS7PEQ==",
+      "dev": true,
       "requires": {
-        "@aws-sdk/node-config-provider": "3.54.1",
-        "@aws-sdk/property-provider": "3.54.1",
-        "@aws-sdk/types": "3.54.1",
-        "@aws-sdk/url-parser": "3.54.1",
-        "tslib": "^2.3.0"
+        "@aws-sdk/node-config-provider": "3.80.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/url-parser": "3.78.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-ini": {
-      "version": "3.54.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.54.1.tgz",
-      "integrity": "sha512-sdLJbNbBJPz4icb4OsbIMtKm2jZqeASBUYBYZfsiNP8E50EZkBOkQuKNzQikzbUZmJN+/U/3YqfrK6NzyzCd3g==",
+      "version": "3.85.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.85.0.tgz",
+      "integrity": "sha512-KgzLGq+w8OrSLutwdYUw0POeLinGQKcqvQJ9702eoeXCwZMnEHwKqU61bn8QKMX/tuYVCNV4I1enI7MmYPW8Lw==",
+      "dev": true,
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.54.1",
-        "@aws-sdk/credential-provider-imds": "3.54.1",
-        "@aws-sdk/credential-provider-sso": "3.54.1",
-        "@aws-sdk/credential-provider-web-identity": "3.54.1",
-        "@aws-sdk/property-provider": "3.54.1",
-        "@aws-sdk/shared-ini-file-loader": "3.54.1",
-        "@aws-sdk/types": "3.54.1",
-        "tslib": "^2.3.0"
+        "@aws-sdk/credential-provider-env": "3.78.0",
+        "@aws-sdk/credential-provider-imds": "3.81.0",
+        "@aws-sdk/credential-provider-sso": "3.85.0",
+        "@aws-sdk/credential-provider-web-identity": "3.78.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/shared-ini-file-loader": "3.80.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-node": {
-      "version": "3.54.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.54.1.tgz",
-      "integrity": "sha512-J6/IjyniCYYJ+Y0cXvuZUB4yIKVOZvwziFwAA/mphtJEyiSjM7cOp3tATCrcBZuZn0OSRAeQlJ6xAy9MbKSHSQ==",
+      "version": "3.85.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.85.0.tgz",
+      "integrity": "sha512-YMxpRJg88mvfmKxy8I5yG3rx+UmF/5a/4twcdAzCfYTAPz+bV6ypIHjFv610/kygHMm29Fof3DRvHXDdBH4mkw==",
+      "dev": true,
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.54.1",
-        "@aws-sdk/credential-provider-imds": "3.54.1",
-        "@aws-sdk/credential-provider-ini": "3.54.1",
-        "@aws-sdk/credential-provider-process": "3.54.1",
-        "@aws-sdk/credential-provider-sso": "3.54.1",
-        "@aws-sdk/credential-provider-web-identity": "3.54.1",
-        "@aws-sdk/property-provider": "3.54.1",
-        "@aws-sdk/shared-ini-file-loader": "3.54.1",
-        "@aws-sdk/types": "3.54.1",
-        "tslib": "^2.3.0"
+        "@aws-sdk/credential-provider-env": "3.78.0",
+        "@aws-sdk/credential-provider-imds": "3.81.0",
+        "@aws-sdk/credential-provider-ini": "3.85.0",
+        "@aws-sdk/credential-provider-process": "3.80.0",
+        "@aws-sdk/credential-provider-sso": "3.85.0",
+        "@aws-sdk/credential-provider-web-identity": "3.78.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/shared-ini-file-loader": "3.80.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-process": {
-      "version": "3.54.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.54.1.tgz",
-      "integrity": "sha512-LeRHa3mCyMsWuRpNeDGLg3KvqqM0hAw1qPszyG5F43x9EhmVCpHPepnf6TrMAbTxpbdhsy4y0+kNLTFxV3LMsw==",
+      "version": "3.80.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.80.0.tgz",
+      "integrity": "sha512-3Ro+kMMyLUJHefOhGc5pOO/ibGcJi8bkj0z/Jtqd5I2Sm1qi7avoztST67/k48KMW1OqPnD/FUqxz5T8B2d+FQ==",
+      "dev": true,
       "requires": {
-        "@aws-sdk/property-provider": "3.54.1",
-        "@aws-sdk/shared-ini-file-loader": "3.54.1",
-        "@aws-sdk/types": "3.54.1",
-        "tslib": "^2.3.0"
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/shared-ini-file-loader": "3.80.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-sso": {
-      "version": "3.54.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.54.1.tgz",
-      "integrity": "sha512-T6fImSfKabjhAk/kgqAhYoDFmV6kRI6PDFEQg9JJ50I61wLqgWIKWQJb0nphNpgGnEVSCp+I9alrahTNXDRQsw==",
+      "version": "3.85.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.85.0.tgz",
+      "integrity": "sha512-uE238BgJ/AftPDlBGDlV0XdiNWnUZxFmUmLxgbr19/6jHaCuBr//T6rP+Bc0BjcHkvQCvTdFoCjs17R3Quy3cw==",
+      "dev": true,
       "requires": {
-        "@aws-sdk/client-sso": "3.54.1",
-        "@aws-sdk/property-provider": "3.54.1",
-        "@aws-sdk/shared-ini-file-loader": "3.54.1",
-        "@aws-sdk/types": "3.54.1",
-        "tslib": "^2.3.0"
+        "@aws-sdk/client-sso": "3.85.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/shared-ini-file-loader": "3.80.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-web-identity": {
-      "version": "3.54.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.54.1.tgz",
-      "integrity": "sha512-wCOK6sK+zS89OetMz8qThqRtgu43dJgpkY7bYjVWlpfnsFGN7aqrNN/N93yhtY/YZmtD/sZVXXgTO2qDkkwl2g==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.78.0.tgz",
+      "integrity": "sha512-9/IvqHdJaVqMEABA8xZE3t5YF1S2PepfckVu0Ws9YUglj6oO+2QyVX6aRgMF1xph6781+Yc31TDh8/3eaDja7w==",
+      "dev": true,
       "requires": {
-        "@aws-sdk/property-provider": "3.54.1",
-        "@aws-sdk/types": "3.54.1",
-        "tslib": "^2.3.0"
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/fetch-http-handler": {
-      "version": "3.54.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.54.1.tgz",
-      "integrity": "sha512-i2sTy8NjFXMtdlaslGS0vKbz1+9J8Nnt1A7A1gWsJmi6cXofv86glKTtxXxr1BsZu82QAZbSO4lm/XAd5gcWuQ==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.78.0.tgz",
+      "integrity": "sha512-cR6r2h2kJ1DNEZSXC6GknQB7OKmy+s9ZNV+g3AsNqkrUmNNOaHpFoSn+m6SC3qaclcGd0eQBpqzSu/TDn23Ihw==",
+      "dev": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.54.1",
-        "@aws-sdk/querystring-builder": "3.54.1",
-        "@aws-sdk/types": "3.54.1",
-        "@aws-sdk/util-base64-browser": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/querystring-builder": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-base64-browser": "3.58.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/hash-node": {
-      "version": "3.54.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.54.1.tgz",
-      "integrity": "sha512-Vpu94h4vla92xLqmAZXHjSF/dw9Myf3Gd4LJMPK7Gb5XZVZgpIijqOF/vlx0YKRunuEopLlT9OFkDVBZtqtTIw==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.78.0.tgz",
+      "integrity": "sha512-ev48yXaqZVtMeuKy52LUZPHCyKvkKQ9uiUebqkA+zFxIk+eN8SMPFHmsififIHWuS6ZkXBUSctjH9wmLebH60A==",
+      "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.54.1",
-        "@aws-sdk/util-buffer-from": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-buffer-from": "3.55.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/invalid-dependency": {
-      "version": "3.54.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.54.1.tgz",
-      "integrity": "sha512-nn+zqJ+nlO5yCxtvykLhj03e2+5wbb4fAgG47PHGCB8zjqvYDlv8jW1sryjR69dsMdylnanUmDvyvJUlQKj3eQ==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.78.0.tgz",
+      "integrity": "sha512-zUo+PbeRMN/Mzj6y+6p9qqk/znuFetT1gmpOcZGL9Rp2T+b9WJWd+daq5ktsL10sVCzIt2UvneJRz6b+aU+bfw==",
+      "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.54.1",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/is-array-buffer": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.52.0.tgz",
-      "integrity": "sha512-5Pe9QKrOeSZb9Z8gtlx9CDMfxH8EiNdClBfXBbc6CiUM7y6l7UintYHkm133zM5XTqtMRYY1jaD8svVAoRPApA==",
+      "version": "3.55.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.55.0.tgz",
+      "integrity": "sha512-NbiPHVYuPxdqdFd6FxzzN3H1BQn/iWA3ri3Ry7AyLeP/tGs1yzEWMwf8BN8TSMALI0GXT6Sh0GDWy3Ok5xB6DA==",
+      "dev": true,
       "requires": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-content-length": {
-      "version": "3.54.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.54.1.tgz",
-      "integrity": "sha512-mnp9GmIDQCtw1XtfnFyBvGLUPD0CGZx1terCoUIWVN+sd8ACpCuDM6wv9TNTU+rxcKkWiOFmNl4becSm46YXOw==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.78.0.tgz",
+      "integrity": "sha512-5MpKt6lB9TdFy25/AGrpOjPY0iDHZAKpEHc+jSOJBXLl6xunXA7qHdiYaVqkWodLxy70nIckGNHqQ3drabidkA==",
+      "dev": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.54.1",
-        "@aws-sdk/types": "3.54.1",
-        "tslib": "^2.3.0"
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-host-header": {
-      "version": "3.54.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.54.1.tgz",
-      "integrity": "sha512-x3RpdcCGu4bvvq5DrluBDCYyOCczcbVCjZm/GBwXy7qddu//1EBtZpJCcJ96ptp1ibjNW48jJPLftel7SK4qAg==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.78.0.tgz",
+      "integrity": "sha512-1zL8uaDWGmH50c8B8jjz75e0ePj6/3QeZEhjJgTgL6DTdiqvRt32p3t+XWHW+yDI14fZZUYeTklAaLVxqFrHqQ==",
+      "dev": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.54.1",
-        "@aws-sdk/types": "3.54.1",
-        "tslib": "^2.3.0"
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-logger": {
-      "version": "3.54.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.54.1.tgz",
-      "integrity": "sha512-Cc7CDFVTAFXjZDNYGduZMWU0F/M5uEeB/GJJGNia3QEMpGjznX7sQH/wbPyVGwcV2/ONSS6NIxhUMnFrb/yl3w==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.78.0.tgz",
+      "integrity": "sha512-GBhwxNjhCJUIeQQDaGasX/C23Jay77al2vRyGwmxf8no0DdFsa4J1Ik6/2hhIqkqko+WM4SpCnpZrY4MtnxNvA==",
+      "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.54.1",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-retry": {
-      "version": "3.54.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.54.1.tgz",
-      "integrity": "sha512-NwF4YU+8qnfD2mimVvlrqPeDUGYRSeoG8eONzC4SajsTRe9oWprRpWgpO47b0P5xrzJRYu18Li6jNz6qR4q4mw==",
+      "version": "3.80.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.80.0.tgz",
+      "integrity": "sha512-CTk+tA4+WMUNOcUfR6UQrkhwvPYFpnMsQ1vuHlpLFOGG3nCqywA2hueLMRQmVcDXzP0sGeygce6dzRI9dJB/GA==",
+      "dev": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.54.1",
-        "@aws-sdk/service-error-classification": "3.54.1",
-        "@aws-sdk/types": "3.54.1",
-        "tslib": "^2.3.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/service-error-classification": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-middleware": "3.78.0",
+        "tslib": "^2.3.1",
         "uuid": "^8.3.2"
       }
     },
     "@aws-sdk/middleware-sdk-sts": {
-      "version": "3.54.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.54.1.tgz",
-      "integrity": "sha512-r4weIvX7YZ62Ag9h+txQDfeK6MlFwZq7YeTYeGN57FF3sPlvMzFvI1BQ+H3A7KlQoXalAL2BzI9GPTkmTEcklg==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.78.0.tgz",
+      "integrity": "sha512-Lu/kN0J0/Kt0ON1hvwNel+y8yvf35licfIgtedHbBCa/ju8qQ9j+uL9Lla6Y5Tqu29yVaye1JxhiIDhscSwrLA==",
+      "dev": true,
       "requires": {
-        "@aws-sdk/middleware-signing": "3.54.1",
-        "@aws-sdk/property-provider": "3.54.1",
-        "@aws-sdk/protocol-http": "3.54.1",
-        "@aws-sdk/signature-v4": "3.54.1",
-        "@aws-sdk/types": "3.54.1",
-        "tslib": "^2.3.0"
+        "@aws-sdk/middleware-signing": "3.78.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/signature-v4": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-serde": {
-      "version": "3.54.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.54.1.tgz",
-      "integrity": "sha512-mOAa54Jwo5pG+Xs5z3VjIi4PMQVRvhsfONTlZV/GRYbJniKVE2/zLZzHLXpeChrdZjHX+kOY/1LSVpypbziu/Q==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.78.0.tgz",
+      "integrity": "sha512-4DPsNOxsl1bxRzfo1WXEZjmD7OEi7qGNpxrDWucVe96Fqj2dH08jR8wxvBIVV1e6bAad07IwdPuCGmivNvwRuQ==",
+      "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.54.1",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-signing": {
-      "version": "3.54.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.54.1.tgz",
-      "integrity": "sha512-orM7cXa14mLmsJXzJrls6iJz5nmICMvx5FP1e0q28TnIgyoqUILcndGzYm3q0l2fwk7BJdw87q6sSy56LWJPkQ==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.78.0.tgz",
+      "integrity": "sha512-OEjJJCNhHHSOprLZ9CzjHIXEKFtPHWP/bG9pMhkV3/6Bmscsgcf8gWHcOnmIrjqX+hT1VALDNpl/RIh0J6/eQw==",
+      "dev": true,
       "requires": {
-        "@aws-sdk/property-provider": "3.54.1",
-        "@aws-sdk/protocol-http": "3.54.1",
-        "@aws-sdk/signature-v4": "3.54.1",
-        "@aws-sdk/types": "3.54.1",
-        "tslib": "^2.3.0"
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/signature-v4": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-stack": {
-      "version": "3.54.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.54.1.tgz",
-      "integrity": "sha512-fh9/jzqR181M+53m0lFHf8HvCKrq6Odu+rzFenumnUjAFaFb7368/XjipqFMxfvW0XjbdGJ4UyPds2wcnqh+8Q==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.78.0.tgz",
+      "integrity": "sha512-UoNfRh6eAJN3BJHlG1eb+KeuSe+zARTC2cglroJRyHc2j7GxH2i9FD3IJbj5wvzopJEnQzuY/VCs6STFkqWL1g==",
+      "dev": true,
       "requires": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-user-agent": {
-      "version": "3.54.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.54.1.tgz",
-      "integrity": "sha512-EXHLYVzUmw6cRc3M+cz3HzDIH9R/5P6kWuaf0762CiG/kDtLr9ya4k3RbBSLAzR4wxuI58U7/DkA6mG5Dne5oA==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.78.0.tgz",
+      "integrity": "sha512-wdN5uoq8RxxhLhj0EPeuDSRFuXfUwKeEqRzCKMsYAOC0cAm+PryaP2leo0oTGJ9LUK8REK7zyfFcmtC4oOzlkA==",
+      "dev": true,
       "requires": {
-        "@aws-sdk/protocol-http": "3.54.1",
-        "@aws-sdk/types": "3.54.1",
-        "tslib": "^2.3.0"
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/node-config-provider": {
-      "version": "3.54.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.54.1.tgz",
-      "integrity": "sha512-Av9Ucybx4NpfLKAVpfBpH0OYWiJ7Da1RYPWyZ9YTKNGTxSUUuS448ZZ0OcP8QDaiHQV40dXGTJz0LV+WfChH8g==",
+      "version": "3.80.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.80.0.tgz",
+      "integrity": "sha512-vyTOMK04huB7n10ZUv0thd2TE6KlY8livOuLqFTMtj99AJ6vyeB5XBNwKnQtJIt/P7CijYgp8KcFvI9fndOmKg==",
+      "dev": true,
       "requires": {
-        "@aws-sdk/property-provider": "3.54.1",
-        "@aws-sdk/shared-ini-file-loader": "3.54.1",
-        "@aws-sdk/types": "3.54.1",
-        "tslib": "^2.3.0"
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/shared-ini-file-loader": "3.80.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/node-http-handler": {
-      "version": "3.54.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.54.1.tgz",
-      "integrity": "sha512-zY9dIIZXms4WcmpcKJxxBPqPydvUTJA3JAoqpf9Huau/oJ4VHYmQCJ6gohmHq2y2f+H0GOf74/QyngncTrKPwg==",
+      "version": "3.82.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.82.0.tgz",
+      "integrity": "sha512-yyq/DA/IMzL4fLJhV7zVfP7aUQWPHfOKTCJjWB3KeV5YPiviJtSKb/KyzNi+gQyO7SmsL/8vQbQrf3/s7N/2OA==",
+      "dev": true,
       "requires": {
-        "@aws-sdk/abort-controller": "3.54.1",
-        "@aws-sdk/protocol-http": "3.54.1",
-        "@aws-sdk/querystring-builder": "3.54.1",
-        "@aws-sdk/types": "3.54.1",
-        "tslib": "^2.3.0"
+        "@aws-sdk/abort-controller": "3.78.0",
+        "@aws-sdk/protocol-http": "3.78.0",
+        "@aws-sdk/querystring-builder": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/property-provider": {
-      "version": "3.54.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.54.1.tgz",
-      "integrity": "sha512-9D7jvMwn4hBemhDjsIduxPvPHdmgdnDjLflc3vNaljcurDUHzJVeJb4pRc3h6Fyaha6hzJFihR63IGdjWfrEhQ==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.78.0.tgz",
+      "integrity": "sha512-PZpLvV0hF6lqg3CSN9YmphrB/t5LVJVWGJLB9d9qm7sJs5ksjTYBb5bY91OQ3zit0F4cqBMU8xt2GQ9J6d4DvQ==",
+      "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.54.1",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/protocol-http": {
-      "version": "3.54.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.54.1.tgz",
-      "integrity": "sha512-2fA8sbFechayTemXogFU3vlllNWYpAI4vE9d3JsIhND2BQHXjv6qrkx9rXWtnALzQbX25D4Rq6Kctu/7hG1jLw==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.78.0.tgz",
+      "integrity": "sha512-SQB26MhEK96yDxyXd3UAaxLz1Y/ZvgE4pzv7V3wZiokdEedM0kawHKEn1UQJlqJLEZcQI9QYyysh3rTvHZ3fyg==",
+      "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.54.1",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/querystring-builder": {
-      "version": "3.54.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.54.1.tgz",
-      "integrity": "sha512-8E4qFyKc4JaZZ+Vg7vV7OZx7DoKqNUakVX9/eZn6W3Hu7rrMcYY3M8mHZggP8z+fosRhib7xOcyh483LMZNfvA==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.78.0.tgz",
+      "integrity": "sha512-aib6RW1WAaTQDqVgRU1Ku9idkhm90gJKbCxVaGId+as6QHNUqMChEfK2v+0afuKiPNOs5uWmqvOXI9+Gt+UGDg==",
+      "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.54.1",
-        "@aws-sdk/util-uri-escape": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-uri-escape": "3.55.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/querystring-parser": {
-      "version": "3.54.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.54.1.tgz",
-      "integrity": "sha512-oqnaGov6PdgS/1lNgkif6EucySMOUAKoNCsABBPItMWAoNmWiDxKIKBlk6xX5s17teP52L/iXAASD/pqeaDmUw==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.78.0.tgz",
+      "integrity": "sha512-csaH8YTyN+KMNczeK6fBS8l7iJaqcQcKOIbpQFg5upX4Ly5A56HJn4sVQhY1LSgfSk4xRsNfMy5mu6BlsIiaXA==",
+      "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.54.1",
-        "tslib": "^2.3.0"
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/service-error-classification": {
-      "version": "3.54.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.54.1.tgz",
-      "integrity": "sha512-cOofY2SFZEoPbuoH4I9ZiTMf8bgUz3OOZjLtU/Qv0Efhf7NhNEwsJkG2jgSYac3UkK7tWyz1Jo1Exog+sY7hOQ=="
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.78.0.tgz",
+      "integrity": "sha512-x7Lx8KWctJa01q4Q72Zb4ol9L/era3vy2daASu8l2paHHxsAPBE0PThkvLdUSLZSzlHSVdh3YHESIsT++VsK4w==",
+      "dev": true
     },
     "@aws-sdk/shared-ini-file-loader": {
-      "version": "3.54.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.54.1.tgz",
-      "integrity": "sha512-Vdb75cv9p7dlBAHFD5LdNW9UhAmTdGTsc4RoJNM2vB08WruPJQkQJgE00/f2o1L7B53mvrH+EHbfJXu5l12jWQ==",
+      "version": "3.80.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.80.0.tgz",
+      "integrity": "sha512-3d5EBJjnWWkjLK9skqLLHYbagtFaZZy+3jUTlbTuOKhlOwe8jF7CUM3j6I4JA6yXNcB3w0exDKKHa8w+l+05aA==",
+      "dev": true,
       "requires": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/signature-v4": {
-      "version": "3.54.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.54.1.tgz",
-      "integrity": "sha512-byBH4ovK3BqVxmsWWlZOug2nfWE2t1Hw1r9B4Cn0kIftpHfy3axVBLTQ8czu5b8mbVyq8PnOKPTZ1X6Tzm/LnQ==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.78.0.tgz",
+      "integrity": "sha512-eePjRYuzKoi3VMr/lgrUEF1ytLeH4fA/NMCykr/uR6NMo4bSJA59KrFLYSM7SlWLRIyB0UvJqygVEvSxFluyDw==",
+      "dev": true,
       "requires": {
-        "@aws-sdk/is-array-buffer": "3.52.0",
-        "@aws-sdk/types": "3.54.1",
-        "@aws-sdk/util-hex-encoding": "3.52.0",
-        "@aws-sdk/util-uri-escape": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/is-array-buffer": "3.55.0",
+        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/util-hex-encoding": "3.58.0",
+        "@aws-sdk/util-middleware": "3.78.0",
+        "@aws-sdk/util-uri-escape": "3.55.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/smithy-client": {
-      "version": "3.54.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.54.1.tgz",
-      "integrity": "sha512-OabAnQQLjhdEMafq4KdptxnmvYXz0fNRZQRU/R4M9PmO5KOO9yep+y8R259hME2uV6FtMTBms1qctN9qaryhug==",
+      "version": "3.85.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.85.0.tgz",
+      "integrity": "sha512-Ox/yQEAnANzhpJMyrpuxWtF/i3EviavENczT7fo4uwSyZTz/sfSBQNjs/YAG1UeA6uOI3pBP5EaFERV5hr2fRA==",
+      "dev": true,
       "requires": {
-        "@aws-sdk/middleware-stack": "3.54.1",
-        "@aws-sdk/types": "3.54.1",
-        "tslib": "^2.3.0"
+        "@aws-sdk/middleware-stack": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/types": {
-      "version": "3.54.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.54.1.tgz",
-      "integrity": "sha512-7JgapyqowaBqhX80ZDxumeLhnyS3Up5ZXn2MljiBwJ2B5mAGomcfFDMDvViJfbKO6pKakopp0iXtPTulH6sIgw=="
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.78.0.tgz",
+      "integrity": "sha512-I9PTlVNSbwhIgMfmDM5as1tqRIkVZunjVmfogb2WVVPp4CaX0Ll01S0FSMSLL9k6tcQLXqh45pFRjrxCl9WKdQ==",
+      "dev": true
     },
     "@aws-sdk/url-parser": {
-      "version": "3.54.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.54.1.tgz",
-      "integrity": "sha512-F0d5UokYgbv80CjZtILZ8y4hWPKwh1sk96hOTi07TBFcx6E5dS5Vi1Wm4GsRi4C8D8FeQ5dhw/XBdqCM3+tloQ==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.78.0.tgz",
+      "integrity": "sha512-iQn2AjECUoJE0Ae9XtgHtGGKvUkvE8hhbktGopdj+zsPBe4WrBN2DgVxlKPPrBonG/YlcL1D7a5EXaujWSlUUw==",
+      "dev": true,
       "requires": {
-        "@aws-sdk/querystring-parser": "3.54.1",
-        "@aws-sdk/types": "3.54.1",
-        "tslib": "^2.3.0"
+        "@aws-sdk/querystring-parser": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-base64-browser": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.52.0.tgz",
-      "integrity": "sha512-xjv/cQ4goWXAiGEC/AIL/GtlHg4p4RkQKs6/zxn9jOxo1OnbppLMJ0LjCtv4/JVYIVGHrx0VJ8Exyod7Ln+NeA==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.58.0.tgz",
+      "integrity": "sha512-0ebsXIZNpu/fup9OgsFPnRKfCFbuuI9PPRzvP6twzLxUB0c/aix6Co7LGHFKcRKHZdaykoJMXArf8eHj2Nzv1Q==",
+      "dev": true,
       "requires": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-base64-node": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.52.0.tgz",
-      "integrity": "sha512-V96YIXBuIiVu7Zk72Y9dly7Io9cYOT30Hjf77KAkBeizlFgT5gWklWYGcytPY8FxLuEy4dPLeHRmgwQnlDwgPA==",
+      "version": "3.55.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.55.0.tgz",
+      "integrity": "sha512-UQ/ZuNoAc8CFMpSiRYmevaTsuRKzLwulZTnM8LNlIt9Wx1tpNvqp80cfvVj7yySKROtEi20wq29h31dZf1eYNQ==",
+      "dev": true,
       "requires": {
-        "@aws-sdk/util-buffer-from": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/util-buffer-from": "3.55.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-body-length-browser": {
-      "version": "3.54.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.54.0.tgz",
-      "integrity": "sha512-hnY9cXbKWJ2Fjb4bK35sFdD4vK+sFe59JtxxI336yYzANulc462LU/J1RgONXYBW60d9iwJ7U+S+9oTJrEH6WQ==",
+      "version": "3.55.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.55.0.tgz",
+      "integrity": "sha512-Ei2OCzXQw5N6ZkTMZbamUzc1z+z1R1Ja5tMEagz5BxuX4vWdBObT+uGlSzL8yvTbjoPjnxWA2aXyEqaUP3JS8Q==",
+      "dev": true,
       "requires": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-body-length-node": {
-      "version": "3.54.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.54.0.tgz",
-      "integrity": "sha512-BBQB3kqHqHQp2GAINJGuse9JBM7hfU0tMp9rfw0nym4C/VRooiJVrIb28tKseLtd7nihXvsZXPvEc2jQBe1Thg==",
+      "version": "3.55.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.55.0.tgz",
+      "integrity": "sha512-lU1d4I+9wJwydduXs0SxSfd+mHKjxeyd39VwOv6i2KSwWkPbji9UQqpflKLKw+r45jL7+xU/zfeTUg5Tt/3Gew==",
+      "dev": true,
       "requires": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-buffer-from": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.52.0.tgz",
-      "integrity": "sha512-hsG0lMlHjJUFoXIy59QLn6x4QU/vp/e0t3EjdD0t8aymB9iuJ43UeLjYTZdrOgtbWb8MXEF747vwg+P6n+4Lxw==",
+      "version": "3.55.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.55.0.tgz",
+      "integrity": "sha512-uVzKG1UgvnV7XX2FPTylBujYMKBPBaq/qFBxfl0LVNfrty7YjpfieQxAe6yRLD+T0Kir/WDQwGvYC+tOYG3IGA==",
+      "dev": true,
       "requires": {
-        "@aws-sdk/is-array-buffer": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/is-array-buffer": "3.55.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-config-provider": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.52.0.tgz",
-      "integrity": "sha512-1wonBNkOOLJpMZnz2Kn69ToFgSoTTyGzJInir8WC5sME3zpkb5j41kTuEVbImNJhVv9MKjmGYrMeZbBVniLRPw==",
+      "version": "3.55.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.55.0.tgz",
+      "integrity": "sha512-30dzofQQfx6tp1jVZkZ0DGRsT0wwC15nEysKRiAcjncM64A0Cm6sra77d0os3vbKiKoPCI/lMsFr4o3533+qvQ==",
+      "dev": true,
       "requires": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.54.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.54.1.tgz",
-      "integrity": "sha512-914CZu8bGQsl3GV5QEzSOsvIadaMtoRZgFRa5XBPcA1yxdUZh7ZIf0cBBwGSKF2tI8Wupcq1WekJsTbVB+9hfg==",
+      "version": "3.85.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.85.0.tgz",
+      "integrity": "sha512-oqK/e2pHuMWrvTJWtDBzylbj232ezlTay5dCq4RQlyi3LPPVBQ08haYD1Mk2ikQ/qa0XvbSD6YVhjpTlvwRNjw==",
+      "dev": true,
       "requires": {
-        "@aws-sdk/property-provider": "3.54.1",
-        "@aws-sdk/types": "3.54.1",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-defaults-mode-node": {
-      "version": "3.54.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.54.1.tgz",
-      "integrity": "sha512-PhG9kevfNOBMqiRBWeFt0B2eeou5xmEr/f5JOVg7rNE8INXwJgRilpjG5f3uDYD25tAVUipLzOeGBx4ay0Y/Gw==",
+      "version": "3.85.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.85.0.tgz",
+      "integrity": "sha512-KDNl4H8jJJLh6y7I3MSwRKe4plKbFKK8MVkS0+Fce/GJh4EnqxF0HzMMaSeNUcPvO2wHRq2a60+XW+0d7eWo1A==",
+      "dev": true,
       "requires": {
-        "@aws-sdk/config-resolver": "3.54.1",
-        "@aws-sdk/credential-provider-imds": "3.54.1",
-        "@aws-sdk/node-config-provider": "3.54.1",
-        "@aws-sdk/property-provider": "3.54.1",
-        "@aws-sdk/types": "3.54.1",
-        "tslib": "^2.3.0"
+        "@aws-sdk/config-resolver": "3.80.0",
+        "@aws-sdk/credential-provider-imds": "3.81.0",
+        "@aws-sdk/node-config-provider": "3.80.0",
+        "@aws-sdk/property-provider": "3.78.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-hex-encoding": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.52.0.tgz",
-      "integrity": "sha512-YYMZg8odn/hBURgL/w82ay2mvPqXHMdujlSndT1ddUSTRoZX67N3hfYYf36nOalDOjNcanIvFHe4Fe8nw+8JiA==",
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.58.0.tgz",
+      "integrity": "sha512-Rl+jXUzk/FJkOLYfUVYPhKa2aUmTpeobRP31l8IatQltSzDgLyRHO35f6UEs7Ztn5s1jbu/POatLAZ2WjbgVyg==",
+      "dev": true,
       "requires": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-locate-window": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.52.0.tgz",
-      "integrity": "sha512-l10U2cLko6070A9DYLJG4NMtwYH8JBG2J/E+RH8uY3lad2o6fGEIkJU0jQbWbUeHYLG3IWuCxT47V4gxYrFj7g==",
+      "version": "3.55.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.55.0.tgz",
+      "integrity": "sha512-0sPmK2JaJE2BbTcnvybzob/VrFKCXKfN4CUKcvn0yGg/me7Bz+vtzQRB3Xp+YSx+7OtWxzv63wsvHoAnXvgxgg==",
+      "dev": true,
       "requires": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-middleware": {
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.78.0.tgz",
+      "integrity": "sha512-Hi3wv2b0VogO4mzyeEaeU5KgIt4qeo0LXU5gS6oRrG0T7s2FyKbMBkJW3YDh/Y8fNwqArZ+/QQFujpP0PIKwkA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-uri-escape": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.52.0.tgz",
-      "integrity": "sha512-W9zw5tE8syjg17jiCYtyF99F0FgDIekQdLg+tQGobw9EtCxlUdg48UYhifPfnjvVyADRX2ntclHF9NmhusOQaQ==",
+      "version": "3.55.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.55.0.tgz",
+      "integrity": "sha512-mmdDLUpFCN2nkfwlLdOM54lTD528GiGSPN1qb8XtGLgZsJUmg3uJSFIN2lPeSbEwJB3NFjVas/rnQC48i7mV8w==",
+      "dev": true,
       "requires": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-user-agent-browser": {
-      "version": "3.54.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.54.1.tgz",
-      "integrity": "sha512-T2ZKGurRIZ4te91JBu95L/hhSm9HwPoFT4c0fhHAiwxgdB3AugDsRePOmGHrZxFEQm9j78Nh3Wh52v8QrAR1QQ==",
+      "version": "3.78.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.78.0.tgz",
+      "integrity": "sha512-diGO/Bf4ggBOEnfD7lrrXaaXOwOXGz0bAJ0HhpizwEMlBld5zfDlWXjNpslh+8+u3EHRjPJQ16KGT6mp/Dm+aw==",
+      "dev": true,
       "requires": {
-        "@aws-sdk/types": "3.54.1",
+        "@aws-sdk/types": "3.78.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-user-agent-node": {
-      "version": "3.54.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.54.1.tgz",
-      "integrity": "sha512-C9FYcV8Sqm1tGddphvi2A50oWyD7eeC/4E6VhPM53/XFYLKVCLOmZkSE2VCHFkmt4GCuyIruADDy4GY/eQ2eLw==",
+      "version": "3.80.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.80.0.tgz",
+      "integrity": "sha512-QV26qIXws1m6sZXg65NS+XrQ5NhAzbDVQLtEVE4nC39UN8fuieP6Uet/gZm9mlLI9hllwvcV7EfgBM3GSC7pZg==",
+      "dev": true,
       "requires": {
-        "@aws-sdk/node-config-provider": "3.54.1",
-        "@aws-sdk/types": "3.54.1",
-        "tslib": "^2.3.0"
+        "@aws-sdk/node-config-provider": "3.80.0",
+        "@aws-sdk/types": "3.78.0",
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-utf8-browser": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.52.0.tgz",
-      "integrity": "sha512-LuOMa9ajWu5fQuYkmvTlQZfHaITkSle+tM/vhbU4JquRN44VUKACjRGT7UEhoU3lCL1BD0JFGMQGHI+5Mmuwfg==",
+      "version": "3.55.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.55.0.tgz",
+      "integrity": "sha512-ljzqJcyjfJpEVSIAxwtIS8xMRUly84BdjlBXyp6cu4G8TUufgjNS31LWdhyGhgmW5vYBNr+LTz0Kwf6J+ou7Ug==",
+      "dev": true,
       "requires": {
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-utf8-node": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.52.0.tgz",
-      "integrity": "sha512-fujr7zeobZ2y5nnOnQZrCPPc+lCAhtNF/LEVslsQfd+AQ0bYWiosrKNetodQVWlfh10E2+i6/5g+1SBJ5kjsLw==",
+      "version": "3.55.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.55.0.tgz",
+      "integrity": "sha512-FsFm7GFaC7j0tlPEm/ri8bU2QCwFW5WKjxUg8lm1oWaxplCpKGUsmcfPJ4sw58GIoyoGu4QXBK60oCWosZYYdQ==",
+      "dev": true,
       "requires": {
-        "@aws-sdk/util-buffer-from": "3.52.0",
-        "tslib": "^2.3.0"
+        "@aws-sdk/util-buffer-from": "3.55.0",
+        "tslib": "^2.3.1"
       }
     },
     "@colors/colors": {
@@ -1149,7 +1223,8 @@
     "bowser": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+      "dev": true
     },
     "boxen": {
       "version": "4.2.0",
@@ -1717,7 +1792,8 @@
     "entities": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "dev": true
     },
     "env-paths": {
       "version": "2.2.1",
@@ -1819,7 +1895,8 @@
     "fast-xml-parser": {
       "version": "3.19.0",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
-      "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg=="
+      "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg==",
+      "dev": true
     },
     "fecha": {
       "version": "4.2.1",
@@ -4561,7 +4638,8 @@
     "uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true
     },
     "validate-npm-package-name": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "proxy-agent": "^5.0.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-cloudwatch-logs": "^3.0.0",
     "@types/node": "13.11.0",
     "@types/winston": "2.4.4",
     "clarify": "^2.1.0",


### PR DESCRIPTION
GitHub Actions tests appear to be failing because `@aws-sdk/client-cloudwatch-logs` does not get installed with `npm ci`. The [correct way](https://stackoverflow.com/a/54305746/2396125) to deal with this issue is to have `@aws-sdk/client-cloudwatch-logs` in both `peerDependencies` and `devDependencies`. This should fix the tests!