### PR TITLE
Run GitHub Actions workflow on pull request

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: Node CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   test:
@@ -24,7 +24,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
       - name: Install dependencies
-        run: |
-          npm ci
+        run: npm ci
       - name: npm test
         run: npm test


### PR DESCRIPTION
This should enable the GitHub Actions workflow to be run on pull requests to ensure tests pass before being merged. Note that the Actions workflow is currently failing and #189 will need to be merged to fix it.