### PR TITLE
update CloudwatchLogs credential object

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ var WinstonCloudWatch = function(options) {
       config = assign(config, options.awsOptions);
     }
 
-    this.cloudwatchlogs = new CloudWatchLogs(config);
+    this.cloudwatchlogs = new CloudWatchLogs({credentials:config});
   }
 
   debug('constructor finished');


### PR DESCRIPTION
allows user provided credentials to work. Prior version was not nested correctly therefore AWS SDK ignored it and used default credentials