### PR TITLE
Fix ES6 import syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ var winston = require('winston'),
 In ES6
 ```js
 import winston from 'winston';
-import WinstonCloudWatch from 'winston-cloudwatch';
+import * as WinstonCloudWatch from 'winston-cloudwatch';
 ```
 
 ```js


### PR DESCRIPTION
Fixes https://github.com/lazywithclass/winston-cloudwatch/issues/104 from happening again