### PR TITLE
fix: the same timestamp logs are reverse sorted

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,7 +118,7 @@ WinstonCloudWatch.prototype.submit = function(callback) {
     this.cloudwatchlogs,
     groupName,
     streamName,
-    this.logEvents.sort((a, b) => (a.timestamp > b.timestamp) ? 1 : -1), // sort events into chronological order https://github.com/lazywithclass/winston-cloudwatch/issues/197
+    this.logEvents.sort((a, b) => a.timestamp - b.timestamp), // sort events into chronological order https://github.com/lazywithclass/winston-cloudwatch/issues/197
     retentionInDays,
     this.options,
     callback


### PR DESCRIPTION
Bugfix: Logs with the same timestamp are sorted in reverse order.

![image](https://user-images.githubusercontent.com/29693033/215004751-c45fb77a-38a8-415d-ae2d-35245e51c784.png)
