### PR TITLE
Make err parameter in TypeScript kthxbye callback optional

### DIFF
--- a/typescript/winston-cloudwatch.d.ts
+++ b/typescript/winston-cloudwatch.d.ts
@@ -6,7 +6,7 @@ import winston = require("winston");
 
 // Declare the default WinstonCloudwatch class
 declare class WinstonCloudwatch extends TransportStream {
-  kthxbye(callback: (err: Error) => void): void;
+  kthxbye(callback: (err?: Error) => void): void;
   upload(
     aws: CloudWatchLogs,
     groupName: string,


### PR DESCRIPTION
If there's no error in kthxbye, the error parameter is not set to anything. For example, [here](https://github.com/lazywithclass/winston-cloudwatch/blob/master/index.js#L139) `callback` is called without any errors.