### PR TITLE
fix documentation. import * as WinstonCloudWatch is not constructable…

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ In ES6
 
 ```js
 import { createLogger, format } from 'winston';
-import * as WinstonCloudWatch from 'winston-cloudwatch';
+import WinstonCloudWatch from 'winston-cloudwatch';
 
 export const log = createLogger({
   level: 'debug',


### PR DESCRIPTION
Fixed documentation for ES6 import.

`import * as WinstonCloudWatch from 'winston-cloudwatch';` is invalid

<img width="1037" alt="image" src="https://github.com/lazywithclass/winston-cloudwatch/assets/22411825/da809b95-9672-44cd-a445-22c2e46dd2c5">

Default import should be used instead.